### PR TITLE
Pod stores linktracker discontinued

### DIFF
--- a/src/components/Projects/Projects.js
+++ b/src/components/Projects/Projects.js
@@ -24,7 +24,9 @@ const containerStyle = {
 };
 
 // Hardcoded list of discontinued and sold project IDs
-const DISCONTINUED_PROJECT_IDS = [1, 4, 6];
+// POD stores are 2–6; only lustigedruckshirts.de (id: 2) is still active.
+// LinkTracker (id: 0) is also discontinued.
+const DISCONTINUED_PROJECT_IDS = [0, 1, 3, 4, 5, 6];
 const SOLD_PROJECT_IDS = [11]; // affiliatecompanies.net
 
 const Projects = () => {


### PR DESCRIPTION
Mark all POD stores except `lustigedruckshirts.de` and `linktracker` as discontinued.

---
<a href="https://cursor.com/background-agent?bcId=bc-bd91485e-46ff-41f6-b8cc-751a1f47d8b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-bd91485e-46ff-41f6-b8cc-751a1f47d8b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates project status mapping used by `Projects.js`.
> 
> - Expands `DISCONTINUED_PROJECT_IDS` to `[0, 1, 3, 4, 5, 6]` (adds LinkTracker and POD stores except `lustigedruckshirts.de`)
> - Clarifies inline comments; `SOLD_PROJECT_IDS` unchanged
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d8671a0d205d57c2bc714200e322e5f3962ec6fd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->