### PR TITLE
Homepage project categories

### DIFF
--- a/public/locales/de/common.json
+++ b/public/locales/de/common.json
@@ -24,7 +24,11 @@
     "subtitle": "Sehen Sie sich einige meiner neuesten Arbeiten an",
     "visit": "Besuchen",
     "discontinued": "EINGESTELLT",
-    "sold": "AKQUIRIERT"
+    "sold": "AKQUIRIERT",
+    "showMore": "Mehr Projekte anzeigen",
+    "showLess": "Weniger Projekte anzeigen",
+    "utilities": "Tools",
+    "inactive": "Inaktiv"
   },
   "technologies": {
     "title": "Technologien",

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -24,7 +24,11 @@
     "subtitle": "Check out some of my recent work",
     "visit": "Visit",
     "discontinued": "DISCONTINUED",
-    "sold": "ACQUIRED"
+    "sold": "ACQUIRED",
+    "showMore": "Show more projects",
+    "showLess": "Show fewer projects",
+    "utilities": "Utilities",
+    "inactive": "Inactive"
   },
   "technologies": {
     "title": "Technologies",

--- a/src/components/Projects/Projects.js
+++ b/src/components/Projects/Projects.js
@@ -2,8 +2,24 @@ import React, { useEffect, useState } from 'react';
 import Masonry from 'react-masonry-css';
 import { useTranslation } from 'next-i18next';
 import Image from 'next/image';
-import { BlogCard, CardInfo, HeaderThree, Hr, Tag, TagList, TitleContent, ImgOverlay, ProjectStatusBanner } from './ProjectsStyles';
+import {
+  BlogCard,
+  CardInfo,
+  HeaderThree,
+  Hr,
+  Tag,
+  TagList,
+  TitleContent,
+  ImgOverlay,
+  ProjectStatusBanner,
+  ProjectsControlsRow,
+  ProjectGroupsWrapper,
+  ProjectGroupDetails,
+  ProjectGroupSummary,
+  ProjectGroupContent,
+} from './ProjectsStyles';
 import { Section, SectionDivider, SectionTitle } from '../../styles/GlobalComponents';
+import Button from '../../styles/GlobalComponents/Button';
 import { projects } from '../../constants/constants';
 
 // Masonry breakpoints
@@ -28,17 +44,156 @@ const containerStyle = {
 // LinkTracker (id: 0) is also discontinued.
 const DISCONTINUED_PROJECT_IDS = [0, 1, 3, 4, 5, 6];
 const SOLD_PROJECT_IDS = [11]; // affiliatecompanies.net
+const FEATURED_PROJECT_IDS = [2, 8, 12, 13, 14]; // lustigedruckshirts.de, print2social, PODB, tierarzt-liste, clipclean
 
 const Projects = () => {
   const { t, i18n } = useTranslation(['common', 'projects']);
   const [discontinuedProjects, setDiscontinuedProjects] = useState(DISCONTINUED_PROJECT_IDS);
   const [soldProjects, setSoldProjects] = useState(SOLD_PROJECT_IDS);
+  const [showMoreProjects, setShowMoreProjects] = useState(false);
   
   useEffect(() => {
     // Force re-render when language changes
     setDiscontinuedProjects([...DISCONTINUED_PROJECT_IDS]);
     setSoldProjects([...SOLD_PROJECT_IDS]);
   }, [i18n.language]);
+
+  const orderedProjects = projects.slice().reverse();
+
+  const isInactiveProjectId = (id) =>
+    discontinuedProjects.includes(id) || soldProjects.includes(id);
+
+  const featuredProjects = orderedProjects.filter(({ id }) =>
+    FEATURED_PROJECT_IDS.includes(id)
+  );
+
+  const utilitiesProjects = orderedProjects.filter(
+    ({ id }) => !FEATURED_PROJECT_IDS.includes(id) && !isInactiveProjectId(id)
+  );
+
+  const inactiveProjects = orderedProjects.filter(
+    ({ id }) => !FEATURED_PROJECT_IDS.includes(id) && isInactiveProjectId(id)
+  );
+
+  const renderProjectCard = ({ id, image, title, description, tags, visit }) => {
+    // Check project status
+    const isDiscontinued = discontinuedProjects.includes(id);
+    const isSold = soldProjects.includes(id);
+
+    // Get translated description with correct path
+    const translatedDescription = t(`projects:projects.${id}.description`, { defaultValue: description });
+
+    // Clean description text by removing status tags
+    const cleanDescription = translatedDescription
+      .replace('[DISCONTINUED]', '')
+      .replace('[EINGESTELLT]', '')
+      .trim();
+
+    return (
+      <BlogCard key={id}>
+        {/* Status banner */}
+        {isDiscontinued && (
+          <ProjectStatusBanner status="discontinued">
+            {t('common:projects.discontinued')}
+          </ProjectStatusBanner>
+        )}
+        {isSold && (
+          <ProjectStatusBanner status="sold">
+            {t('common:projects.sold')}
+          </ProjectStatusBanner>
+        )}
+
+        {/* Wrap the entire card in a link if not discontinued or sold */}
+        {(isDiscontinued || isSold) ? (
+          <>
+            {/* Image with grayscale for discontinued/sold projects */}
+            {image && (
+              <ImgOverlay>
+                <div style={{ position: 'relative', width: '100%', height: '200px' }}>
+                  <Image 
+                    src={image} 
+                    alt={title} 
+                    fill
+                    sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
+                    style={{ 
+                      objectFit: 'cover',
+                      filter: 'grayscale(100%)',
+                      borderRadius: '12px 12px 0 0'
+                    }}
+                    priority={id === 12}
+                    loading={id === 12 ? "eager" : "lazy"}
+                    quality={id === 12 ? 90 : 75}
+                    placeholder="blur"
+                    blurDataURL="data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/4gHYSUNDX1BST0ZJTEUAAQEAAAHIAAAAAAQwAABtbnRyUkdCIFhZWiAH4AABAAEAAAAAAABhY3NwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAA9tYAAQAAAADTLQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAlkZXNjAAAA8AAAACRyWFlaAAABFAAAABRnWFlaAAABKAAAABRiWFlaAAABPAAAABR3dHB0AAABUAAAABRyVFJDAAABZAAAAChnVFJDAAABZAAAAChiVFJDAAABZAAAAChjcHJ0AAABjAAAADxtbHVjAAAAAAAAAAEAAAAMZW5VUwAAAAgAAAAcAHMAUgBHAEJYWVogAAAAAAAAb6IAADj1AAADkFhZWiAAAAAAAABimQAAt4UAABjaWFlaIAAAAAAAACSgAAAPhAAAts9YWVogAAAAAAAA9tYAAQAAAADTLXBhcmEAAAAAAAQAAAACZmYAAPKnAAANWQAAE9AAAApbAAAAAAAAAABtbHVjAAAAAAAAAAEAAAAMZW5VUwAAACAAAAAcAEcAbwBvAGcAbABlACAASQBuAGMALgAgADIAMAAxADb/2wBDABQODxIPDRQSEBIXFRQdHx4eHRoaHSQtJSEkLzYvLy82NDQ0NDY0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDT/2wBDAR0XFyAeIR4hISE0LSotNDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDT/wAARCAAIAAoDASIAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAb/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/8QAFQEBAQAAAAAAAAAAAAAAAAAAAAb/xAAUEQEAAAAAAAAAAAAAAAAAAAAA/9oADAMBAAIRAxEAPwCdABmX/9k="
+                  />
+                </div>
+              </ImgOverlay>
+            )}
+
+            <TitleContent>
+              <HeaderThree title={title}>
+                <span>{title}</span>
+              </HeaderThree>
+              <Hr />
+            </TitleContent>
+            <CardInfo>{cleanDescription}</CardInfo>
+            <div>
+              <TagList>
+                {tags.map((tag, i) => (
+                  <Tag key={i}>{tag}</Tag>
+                ))}
+              </TagList>
+            </div>
+          </>
+        ) : (
+          <a href={visit} target="_blank" rel="noopener noreferrer" style={{ 
+            display: 'block', 
+            textDecoration: 'none',
+            color: 'inherit',
+            height: '100%'
+          }}>
+            {/* Image for active projects */}
+            {image && (
+              <ImgOverlay>
+                <div style={{ position: 'relative', width: '100%', height: '200px' }}>
+                  <Image 
+                    src={image} 
+                    alt={title} 
+                    fill
+                    sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
+                    style={{ 
+                      objectFit: 'cover',
+                      borderRadius: '12px 12px 0 0'
+                    }}
+                    priority={id === 12}
+                    loading={id === 12 ? "eager" : "lazy"}
+                    quality={id === 12 ? 90 : 75}
+                    placeholder="blur"
+                    blurDataURL="data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/4gHYSUNDX1BST0ZJTEUAAQEAAAHIAAAAAAQwAABtbnRyUkdCIFhZWiAH4AABAAEAAAAAAABhY3NwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAA9tYAAQAAAADTLQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAlkZXNjAAAA8AAAACRyWFlaAAABFAAAABRnWFlaAAABKAAAABRiWFlaAAABPAAAABR3dHB0AAABUAAAABRyVFJDAAABZAAAAChnVFJDAAABZAAAAChiVFJDAAABZAAAAChjcHJ0AAABjAAAADxtbHVjAAAAAAAAAAEAAAAMZW5VUwAAAAgAAAAcAHMAUgBHAEJYWVogAAAAAAAAb6IAADj1AAADkFhZWiAAAAAAAABimQAAt4UAABjaWFlaIAAAAAAAACSgAAAPhAAAts9YWVogAAAAAAAA9tYAAQAAAADTLXBhcmEAAAAAAAQAAAACZmYAAPKnAAANWQAAE9AAAApbAAAAAAAAAABtbHVjAAAAAAAAAAEAAAAMZW5VUwAAACAAAAAcAEcAbwBvAGcAbABlACAASQBuAGMALgAgADIAMAAxADb/2wBDABQODxIPDRQSEBIXFRQdHx4eHRoaHSQtJSEkLzYvLy82NDQ0NDY0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDT/2wBDAR0XFyAeIR4hISE0LSotNDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDT/wAARCAAIAAoDASIAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAb/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/8QAFQEBAQAAAAAAAAAAAAAAAAAAAAb/xAAUEQEAAAAAAAAAAAAAAAAAAAAA/9oADAMBAAIRAxEAPwCdABmX/9k="
+                  />
+                </div>
+              </ImgOverlay>
+            )}
+
+            <TitleContent>
+              <HeaderThree title={title}>
+                {title}
+              </HeaderThree>
+              <Hr />
+            </TitleContent>
+            <CardInfo>{cleanDescription}</CardInfo>
+            <div>
+              <TagList>
+                {tags.map((tag, i) => (
+                  <Tag key={i}>{tag}</Tag>
+                ))}
+              </TagList>
+            </div>
+          </a>
+        )}
+      </BlogCard>
+    );
+  };
   
   return (
     <Section id="projects">
@@ -50,127 +205,59 @@ const Projects = () => {
           className="my-masonry-grid"
           columnClassName="my-masonry-grid_column"
         >
-          {projects.slice().reverse().map(({ id, image, title, description, tags, visit }) => {
-            // Check project status
-            const isDiscontinued = discontinuedProjects.includes(id);
-            const isSold = soldProjects.includes(id);
-            
-            // Get translated description with correct path
-            const translatedDescription = t(`projects:projects.${id}.description`, { defaultValue: description });
-            
-            // Clean description text by removing status tags
-            const cleanDescription = translatedDescription
-              .replace('[DISCONTINUED]', '')
-              .replace('[EINGESTELLT]', '')
-              .trim();
-            
-            return (
-              <BlogCard key={id}>
-                {/* Status banner */}
-                {isDiscontinued && (
-                  <ProjectStatusBanner status="discontinued">
-                    {t('common:projects.discontinued')}
-                  </ProjectStatusBanner>
-                )}
-                {isSold && (
-                  <ProjectStatusBanner status="sold">
-                    {t('common:projects.sold')}
-                  </ProjectStatusBanner>
-                )}
-                
-                {/* Wrap the entire card in a link if not discontinued or sold */}
-                {(isDiscontinued || isSold) ? (
-                  <>
-                    {/* Image with grayscale for discontinued/sold projects */}
-                    {image && (
-                      <ImgOverlay>
-                        <div style={{ position: 'relative', width: '100%', height: '200px' }}>
-                          <Image 
-                            src={image} 
-                            alt={title} 
-                            fill
-                            sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
-                            style={{ 
-                              objectFit: 'cover',
-                              filter: 'grayscale(100%)',
-                              borderRadius: '12px 12px 0 0'
-                            }}
-                            priority={id === 12}
-                            loading={id === 12 ? "eager" : "lazy"}
-                            quality={id === 12 ? 90 : 75}
-                            placeholder="blur"
-                            blurDataURL="data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/4gHYSUNDX1BST0ZJTEUAAQEAAAHIAAAAAAQwAABtbnRyUkdCIFhZWiAH4AABAAEAAAAAAABhY3NwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAA9tYAAQAAAADTLQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAlkZXNjAAAA8AAAACRyWFlaAAABFAAAABRnWFlaAAABKAAAABRiWFlaAAABPAAAABR3dHB0AAABUAAAABRyVFJDAAABZAAAAChnVFJDAAABZAAAAChiVFJDAAABZAAAAChjcHJ0AAABjAAAADxtbHVjAAAAAAAAAAEAAAAMZW5VUwAAAAgAAAAcAHMAUgBHAEJYWVogAAAAAAAAb6IAADj1AAADkFhZWiAAAAAAAABimQAAt4UAABjaWFlaIAAAAAAAACSgAAAPhAAAts9YWVogAAAAAAAA9tYAAQAAAADTLXBhcmEAAAAAAAQAAAACZmYAAPKnAAANWQAAE9AAAApbAAAAAAAAAABtbHVjAAAAAAAAAAEAAAAMZW5VUwAAACAAAAAcAEcAbwBvAGcAbABlACAASQBuAGMALgAgADIAMAAxADb/2wBDABQODxIPDRQSEBIXFRQdHx4eHRoaHSQtJSEkLzYvLy82NDQ0NDY0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDT/2wBDAR0XFyAeIR4hISE0LSotNDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDT/wAARCAAIAAoDASIAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAb/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/8QAFQEBAQAAAAAAAAAAAAAAAAAAAAb/xAAUEQEAAAAAAAAAAAAAAAAAAAAA/9oADAMBAAIRAxEAPwCdABmX/9k="
-                          />
-                        </div>
-                      </ImgOverlay>
-                    )}
-                    
-                    <TitleContent>
-                      <HeaderThree title={title}>
-                        <span>{title}</span>
-                      </HeaderThree>
-                      <Hr />
-                    </TitleContent>
-                    <CardInfo>{cleanDescription}</CardInfo>
-                    <div>
-                      <TagList>
-                        {tags.map((tag, i) => (
-                          <Tag key={i}>{tag}</Tag>
-                        ))}
-                      </TagList>
-                    </div>
-                  </>
-                ) : (
-                  <a href={visit} target="_blank" rel="noopener noreferrer" style={{ 
-                    display: 'block', 
-                    textDecoration: 'none',
-                    color: 'inherit',
-                    height: '100%'
-                  }}>
-                    {/* Image for active projects */}
-                    {image && (
-                      <ImgOverlay>
-                        <div style={{ position: 'relative', width: '100%', height: '200px' }}>
-                          <Image 
-                            src={image} 
-                            alt={title} 
-                            fill
-                            sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
-                            style={{ 
-                              objectFit: 'cover',
-                              borderRadius: '12px 12px 0 0'
-                            }}
-                            priority={id === 12}
-                            loading={id === 12 ? "eager" : "lazy"}
-                            quality={id === 12 ? 90 : 75}
-                            placeholder="blur"
-                            blurDataURL="data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/4gHYSUNDX1BST0ZJTEUAAQEAAAHIAAAAAAQwAABtbnRyUkdCIFhZWiAH4AABAAEAAAAAAABhY3NwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAA9tYAAQAAAADTLQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAlkZXNjAAAA8AAAACRyWFlaAAABFAAAABRnWFlaAAABKAAAABRiWFlaAAABPAAAABR3dHB0AAABUAAAABRyVFJDAAABZAAAAChnVFJDAAABZAAAAChiVFJDAAABZAAAAChjcHJ0AAABjAAAADxtbHVjAAAAAAAAAAEAAAAMZW5VUwAAAAgAAAAcAHMAUgBHAEJYWVogAAAAAAAAb6IAADj1AAADkFhZWiAAAAAAAABimQAAt4UAABjaWFlaIAAAAAAAACSgAAAPhAAAts9YWVogAAAAAAAA9tYAAQAAAADTLXBhcmEAAAAAAAQAAAACZmYAAPKnAAANWQAAE9AAAApbAAAAAAAAAABtbHVjAAAAAAAAAAEAAAAMZW5VUwAAACAAAAAcAEcAbwBvAGcAbABlACAASQBuAGMALgAgADIAMAAxADb/2wBDABQODxIPDRQSEBIXFRQdHx4eHRoaHSQtJSEkLzYvLy82NDQ0NDY0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDT/2wBDAR0XFyAeIR4hISE0LSotNDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDT/wAARCAAIAAoDASIAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAb/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/8QAFQEBAQAAAAAAAAAAAAAAAAAAAAb/xAAUEQEAAAAAAAAAAAAAAAAAAAAA/9oADAMBAAIRAxEAPwCdABmX/9k="
-                          />
-                        </div>
-                      </ImgOverlay>
-                    )}
-                    
-                    <TitleContent>
-                      <HeaderThree title={title}>
-                        {title}
-                      </HeaderThree>
-                      <Hr />
-                    </TitleContent>
-                    <CardInfo>{cleanDescription}</CardInfo>
-                    <div>
-                      <TagList>
-                        {tags.map((tag, i) => (
-                          <Tag key={i}>{tag}</Tag>
-                        ))}
-                      </TagList>
-                    </div>
-                  </a>
-                )}
-              </BlogCard>
-            );
-          })}
+          {featuredProjects.map(renderProjectCard)}
         </Masonry>
       </div>
+
+      {(utilitiesProjects.length > 0 || inactiveProjects.length > 0) && (
+        <ProjectsControlsRow>
+          <Button onClick={() => setShowMoreProjects((prev) => !prev)}>
+            {showMoreProjects ? t('common:projects.showLess') : t('common:projects.showMore')}
+          </Button>
+        </ProjectsControlsRow>
+      )}
+
+      {showMoreProjects && (
+        <ProjectGroupsWrapper>
+          {utilitiesProjects.length > 0 && (
+            <ProjectGroupDetails open>
+              <ProjectGroupSummary>
+                {t('common:projects.utilities')} ({utilitiesProjects.length})
+              </ProjectGroupSummary>
+              <ProjectGroupContent>
+                <div style={containerStyle}>
+                  <Masonry
+                    breakpointCols={breakpointColumnsObj}
+                    className="my-masonry-grid"
+                    columnClassName="my-masonry-grid_column"
+                  >
+                    {utilitiesProjects.map(renderProjectCard)}
+                  </Masonry>
+                </div>
+              </ProjectGroupContent>
+            </ProjectGroupDetails>
+          )}
+
+          {inactiveProjects.length > 0 && (
+            <ProjectGroupDetails>
+              <ProjectGroupSummary>
+                {t('common:projects.inactive')} ({inactiveProjects.length})
+              </ProjectGroupSummary>
+              <ProjectGroupContent>
+                <div style={containerStyle}>
+                  <Masonry
+                    breakpointCols={breakpointColumnsObj}
+                    className="my-masonry-grid"
+                    columnClassName="my-masonry-grid_column"
+                  >
+                    {inactiveProjects.map(renderProjectCard)}
+                  </Masonry>
+                </div>
+              </ProjectGroupContent>
+            </ProjectGroupDetails>
+          )}
+        </ProjectGroupsWrapper>
+      )}
     </Section>
   );
 };

--- a/src/components/Projects/ProjectsStyles.js
+++ b/src/components/Projects/ProjectsStyles.js
@@ -163,3 +163,43 @@ export const ProjectStatusBanner = styled.div`
     }
   }};
 `
+
+export const ProjectsControlsRow = styled.div`
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  margin: 24px 0 0;
+`;
+
+export const ProjectGroupsWrapper = styled.div`
+  width: 100%;
+  max-width: 1200px;
+  margin: 28px auto 0;
+`;
+
+export const ProjectGroupDetails = styled.details`
+  width: 100%;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.03);
+  padding: 10px 14px;
+  margin-bottom: 14px;
+`;
+
+export const ProjectGroupSummary = styled.summary`
+  cursor: pointer;
+  list-style: none;
+  font-weight: 600;
+  letter-spacing: 1px;
+  color: rgba(255, 255, 255, 0.92);
+  padding: 6px 2px;
+  user-select: none;
+
+  &::-webkit-details-marker {
+    display: none;
+  }
+`;
+
+export const ProjectGroupContent = styled.div`
+  margin-top: 16px;
+`;


### PR DESCRIPTION
Split projects into categories and show only featured projects on the homepage by default, with a "Show more" toggle for others.

---
<a href="https://cursor.com/background-agent?bcId=bc-7b1e3d3e-009d-4f0b-921e-c15205f1eee5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7b1e3d3e-009d-4f0b-921e-c15205f1eee5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces categorized project display with a focus on featured items and optional expansion for the rest.
> 
> - Renders only `featuredProjects` in the initial masonry grid; adds `Show more/Show less` control
> - Adds collapsible groups for `utilities` and `inactive` projects with counts; refactors card rendering into `renderProjectCard`
> - Adds new styled components: `ProjectsControlsRow`, `ProjectGroupsWrapper`, `ProjectGroupDetails`, `ProjectGroupSummary`, `ProjectGroupContent`
> - Updates i18n (`en`, `de`) with `projects.showMore`, `projects.showLess`, `projects.utilities`, `projects.inactive`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 16a57cd6563e743c2ebbd4149011dbcd2ce21d7c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->