### PR TITLE
Homepage trust messaging

### DIFF
--- a/public/locales/de/common.json
+++ b/public/locales/de/common.json
@@ -1,12 +1,22 @@
 {
   "meta": {
-    "title": "Samir Alibabic - Software-Ingenieur & Digital Unternehmer",
-    "description": "Portfolio von Samir Alibabic - Präsentation von Projekten und Fähigkeiten im Bereich Software-Engineering, Indie-Hacking und Unternehmertum."
+    "title": "Samir Alibabic - Software-Ingenieur & Solo-Entrepreneur",
+    "description": "Ich baue und betreibe Software-Produkte end-to-end – von Code & Daten bis Distribution. Fokus: organisches Wachstum (SEO/Content/Community) und klare, messbare Systeme."
   },
   "hero": {
-    "title": "Software-Ingenieur & Digital Unternehmer",
-    "intro": "Ich entwickle und skaliere digitale Produkte, die Unternehmen beim Wachstum helfen. Entdecken Sie mein Portfolio aus SaaS-Tools, Verzeichnissen und E-Commerce-Ventures, die tausenden von Nutzern und Partnern weltweit Mehrwert bieten.",
-    "contact": "Kontaktieren Sie mich"
+    "title": "Software-Ingenieur & Solo-Entrepreneur",
+    "intro": "Ich baue und betreibe Software-Produkte end-to-end – von Code & Daten bis Distribution.",
+    "introSecondLine": "Fokus: organisches Wachstum (SEO/Content/Community) und klare, messbare Systeme.",
+    "contact": "Kontakt",
+    "exploreProducts": "Produkte ansehen",
+    "readBlog": "Blog lesen",
+    "proofChips": {
+      "mau": "4.2k+ MAU über aktive Produkte",
+      "solo": "Solo seit 2024",
+      "valtech": "Valtech (2016–2022)",
+      "germany": "Deutschland",
+      "since": "Seit 2009 in Software"
+    }
   },
   "navigation": {
     "projects": "Projekte",
@@ -32,7 +42,8 @@
   },
   "technologies": {
     "title": "Technologien",
-    "subtitle": "Im Laufe meiner Karriere habe ich mit einer Vielzahl von Technologien auf unterschiedlichen Kompetenzniveaus gearbeitet, aber heutzutage setze ich hauptsächlich auf schnelle Entwicklung mit No-Code/Low-Code-Tools und KI.",
+    "subtitle": "Ich nutze das passende Werkzeug für den Job – Fokus auf schnelle Umsetzung, Zuverlässigkeit und messbare Ergebnisse.",
+    "subtitleSecondLine": "Technologie ist Mittel zum Zweck: Delivery, Qualität und Wachstum stehen im Vordergrund.",
     "frontend": "Front-End",
     "backend": "Back-End",
     "devops": "DevOps",
@@ -71,11 +82,31 @@
   "about": {
     "title": "Über Mich",
     "subtitle": "Mein Hintergrund und meine Reise",
-    "ageText": "Seit ich vor {{years}} Jahren, {{months}} Monaten, {{days}} Tagen, {{hours}} Stunden, {{minutes}} Minuten und {{seconds}} Sekunden geboren wurde, habe ich Folgendes erreicht:"
+    "bioLine1": "Ich entwickle seit 2009 Software und baue seit 2024 Produkte als Solo-Unternehmer.",
+    "bioLine2": "Davor: Software Engineer bei Valtech (2016–2022).",
+    "bioLine3": "Heute: organisches Wachstum, klare Systeme und Produkte mit eigener Distribution."
   },
   "testimonials": {
     "title": "Referenzen",
     "subtitle": "Was andere über meine Arbeit sagen"
+  },
+  "outcomes": {
+    "title": "Ausgewählte Ergebnisse",
+    "mau": "4.2k+ MAU über aktive Produkte",
+    "portfolio": "Portfolio: Software-Produkte, Verzeichnisse & Tools",
+    "experience": "Solo seit 2024 · Valtech 2016–2022"
+  },
+  "contact": {
+    "sendEmail": "E-Mail senden",
+    "pleaseInclude": "Bitte mitschicken:",
+    "whatAbout": "Worum geht's?",
+    "linkProduct": "Link/Produkt",
+    "nextStep": "Gewünschter nächster Schritt"
+  },
+  "now": {
+    "title": "Aktuell",
+    "focus": "Aktuell: Fokus auf PODB & Tierarzt-Liste (Wachstum + Monetarisierung).",
+    "openTo": "Offen für: Sponsorships, Integrationen, Partnerschaften."
   },
   "footer": {
     "privacy": "Datenschutzerklärung",

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -1,12 +1,22 @@
 {
   "meta": {
-    "title": "Samir Alibabic - Software Engineer & Digital Entrepreneur",
-    "description": "Portfolio of Samir Alibabic - Showcasing projects and skills in software engineering, indie hacking, and entrepreneurship."
+    "title": "Samir Alibabic - Software Engineer & Solo Founder",
+    "description": "I build and operate software products end-to-end — from code & data to distribution. Focus: organic growth (SEO/content/community) and clear, measurable systems."
   },
   "hero": {
-    "title": "Software Engineer & Digital Entrepreneur",
-    "intro": "I build and scale digital products that help businesses grow. Explore my portfolio of SaaS tools, directories, and e-commerce ventures delivering value to thousands of users and partners worldwide.",
-    "contact": "Contact me"
+    "title": "Software Engineer & Solo Founder",
+    "intro": "I build and operate software products end-to-end — from code & data to distribution.",
+    "introSecondLine": "Focus: organic growth (SEO/content/community) and clear, measurable systems.",
+    "contact": "Contact",
+    "exploreProducts": "Explore products",
+    "readBlog": "Read the blog",
+    "proofChips": {
+      "mau": "4.2k+ MAU across active products",
+      "solo": "Solo since 2024",
+      "valtech": "Valtech (2016–2022)",
+      "germany": "Germany",
+      "since": "Building since 2009"
+    }
   },
   "navigation": {
     "projects": "Projects",
@@ -32,7 +42,8 @@
   },
   "technologies": {
     "title": "Technologies",
-    "subtitle": "Over the course of my career, I have worked with a wide range of technologies, with different levels of proficiency, but nowadays I mostly ship fast with no-code/low-code tools and AI.",
+    "subtitle": "I use the right tool for the job — with a focus on speed, reliability, and measurable outcomes.",
+    "subtitleSecondLine": "Technology is a means to an end: delivery, quality, and growth come first.",
     "frontend": "Front-End",
     "backend": "Back-End",
     "devops": "DevOps",
@@ -71,11 +82,31 @@
   "about": {
     "title": "About Me",
     "subtitle": "My background and journey",
-    "ageText": "Since I've been born {{years}} years, {{months}} months, {{days}} days, {{hours}} hours, {{minutes}} minutes, and {{seconds}} seconds ago, I've managed to accomplish the following:"
+    "bioLine1": "I've been building software since 2009 and have been operating products as a solo founder since 2024.",
+    "bioLine2": "Previously: Software Engineer at Valtech (2016–2022).",
+    "bioLine3": "Today: organic growth, clear systems, and products with their own distribution."
   },
   "testimonials": {
     "title": "Testimonials",
     "subtitle": "What people say about my work"
+  },
+  "outcomes": {
+    "title": "Selected Outcomes",
+    "mau": "4.2k+ MAU across active products",
+    "portfolio": "Portfolio: software products, directories & tools",
+    "experience": "Solo since 2024 · Valtech 2016–2022"
+  },
+  "contact": {
+    "sendEmail": "Send email",
+    "pleaseInclude": "Please include:",
+    "whatAbout": "What is this about?",
+    "linkProduct": "Link/product",
+    "nextStep": "Desired next step"
+  },
+  "now": {
+    "title": "Now",
+    "focus": "Now: focused on PODB & Tierarzt-Liste (growth + monetization).",
+    "openTo": "Open to: sponsorships, integrations, partnerships."
   },
   "footer": {
     "privacy": "Privacy Policy",

--- a/src/components/Footer/Footer.js
+++ b/src/components/Footer/Footer.js
@@ -3,7 +3,7 @@ import Link from 'next/link';
 import { useTranslation } from 'next-i18next';
 
 import SocialIconsGroup from '../SocialIcons/SocialIcons';
-import { CompanyContainer, FooterWrapper, LinkColumn, LinkItem, LinkList, LinkTitle, Slogan, LegalLinks, LegalNavLink, SocialIconsContainer } from './FooterStyles';
+import { CompanyContainer, FooterWrapper, LinkColumn, LinkItem, LinkList, LinkTitle, Slogan, LegalLinks, LegalNavLink, SocialIconsContainer, ContactButton, ContactHints, ContactHintItem, ContactSection, NowSection, NowText } from './FooterStyles';
 
 const Footer = () => {
   const { t } = useTranslation('common');
@@ -12,10 +12,25 @@ const Footer = () => {
     <FooterWrapper>
 
       <LinkList id='contact'>
-        <LinkColumn>
+        <ContactSection>
           <LinkTitle>{t('footer.email', 'E-Mail')}</LinkTitle>
           <LinkItem>kontakt-at-samiralibabic.de</LinkItem>
-        </LinkColumn>
+          <ContactButton href="mailto:kontakt@samiralibabic.de">
+            {t('contact.sendEmail')}
+          </ContactButton>
+          <ContactHints>
+            <span style={{ fontWeight: 500, marginBottom: '8px', display: 'block' }}>{t('contact.pleaseInclude')}</span>
+            <ContactHintItem>• {t('contact.whatAbout')}</ContactHintItem>
+            <ContactHintItem>• {t('contact.linkProduct')}</ContactHintItem>
+            <ContactHintItem>• {t('contact.nextStep')}</ContactHintItem>
+          </ContactHints>
+        </ContactSection>
+        
+        <NowSection>
+          <LinkTitle>{t('now.title')}</LinkTitle>
+          <NowText>{t('now.focus')}</NowText>
+          <NowText>{t('now.openTo')}</NowText>
+        </NowSection>
       </LinkList>
 
       <SocialIconsContainer>

--- a/src/components/Footer/FooterStyles.js
+++ b/src/components/Footer/FooterStyles.js
@@ -189,3 +189,88 @@ export const LegalNavLink = styled(NavLink)`
 		align-items: center;
 	}
 `
+
+export const ContactSection = styled.div`
+	display: flex;
+	flex-direction: column;
+	max-width: 300px;
+	width: 100%;
+`
+
+export const ContactButton = styled.a`
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	padding: 12px 24px;
+	background: linear-gradient(270deg, #13ADC7 0%, #945DD6 100%);
+	border: none;
+	border-radius: 50px;
+	font-size: 16px;
+	font-weight: 600;
+	color: #fff;
+	text-decoration: none;
+	cursor: pointer;
+	transition: all 0.3s ease;
+	margin: 16px 0;
+	width: fit-content;
+
+	&:hover {
+		transform: translateY(-2px);
+		box-shadow: 0 4px 20px rgba(19, 173, 199, 0.4);
+	}
+
+	@media ${props => props.theme.breakpoints.sm} {
+		padding: 10px 20px;
+		font-size: 14px;
+		width: 100%;
+		justify-content: center;
+	}
+`
+
+export const ContactHints = styled.div`
+	margin-top: 8px;
+	padding: 12px;
+	background: rgba(255, 255, 255, 0.03);
+	border-radius: 8px;
+	border: 1px solid rgba(255, 255, 255, 0.08);
+
+	@media ${props => props.theme.breakpoints.sm} {
+		padding: 10px;
+	}
+`
+
+export const ContactHintItem = styled.p`
+	font-size: 14px;
+	line-height: 22px;
+	color: rgba(255, 255, 255, 0.65);
+	margin: 4px 0;
+
+	@media ${props => props.theme.breakpoints.sm} {
+		font-size: 12px;
+		line-height: 18px;
+	}
+`
+
+export const NowSection = styled.div`
+	display: flex;
+	flex-direction: column;
+	max-width: 400px;
+	width: 100%;
+`
+
+export const NowText = styled.p`
+	font-size: 16px;
+	line-height: 26px;
+	color: rgba(255, 255, 255, 0.75);
+	margin-bottom: 8px;
+
+	@media ${props => props.theme.breakpoints.md} {
+		font-size: 14px;
+		line-height: 22px;
+	}
+
+	@media ${props => props.theme.breakpoints.sm} {
+		font-size: 13px;
+		line-height: 20px;
+	}
+`

--- a/src/components/Hero/Hero.js
+++ b/src/components/Hero/Hero.js
@@ -3,8 +3,7 @@ import { useTranslation } from 'next-i18next';
 
 import { SectionText, SectionTitle } from '../../styles/GlobalComponents';
 import Button from '../../styles/GlobalComponents/Button';
-import { LeftSection } from './HeroStyles';
-import Link from 'next/link';
+import { LeftSection, ProofChipsContainer, ProofChip, SecondaryButtonsContainer, SecondaryButton } from './HeroStyles';
 
 const Hero = (props) => {
   const { t } = useTranslation('common');
@@ -16,8 +15,20 @@ const Hero = (props) => {
       </SectionTitle>
       <SectionText>
         {t('hero.intro')}
+        <br />
+        <span style={{ opacity: 0.8 }}>{t('hero.introSecondLine')}</span>
       </SectionText>
+      <ProofChipsContainer>
+        <ProofChip>{t('hero.proofChips.mau')}</ProofChip>
+        <ProofChip>{t('hero.proofChips.solo')}</ProofChip>
+        <ProofChip>{t('hero.proofChips.valtech')}</ProofChip>
+        <ProofChip>{t('hero.proofChips.germany')}</ProofChip>
+      </ProofChipsContainer>
       <Button onClick={() => window.location = '#contact'}>{t('hero.contact')}</Button>
+      <SecondaryButtonsContainer>
+        <SecondaryButton href="#projects">{t('hero.exploreProducts')}</SecondaryButton>
+        <SecondaryButton href="https://blog.samiralibabic.com" target="_blank" rel="noopener noreferrer">{t('hero.readBlog')}</SecondaryButton>
+      </SecondaryButtonsContainer>
     </LeftSection>
   );
 };

--- a/src/components/Hero/HeroStyles.js
+++ b/src/components/Hero/HeroStyles.js
@@ -17,3 +17,89 @@ export const LeftSection = styled.div`
     margin: 0 auto;
   }
 `;
+
+export const ProofChipsContainer = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 24px;
+  
+  @media ${(props) => props.theme.breakpoints.md} {
+    margin-bottom: 20px;
+    gap: 6px;
+  }
+  
+  @media ${(props) => props.theme.breakpoints.sm} {
+    margin-bottom: 16px;
+    gap: 6px;
+    justify-content: flex-start;
+  }
+`;
+
+export const ProofChip = styled.span`
+  display: inline-flex;
+  align-items: center;
+  padding: 6px 12px;
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 20px;
+  font-size: 14px;
+  font-weight: 500;
+  color: rgba(255, 255, 255, 0.85);
+  white-space: nowrap;
+  
+  @media ${(props) => props.theme.breakpoints.md} {
+    padding: 5px 10px;
+    font-size: 13px;
+  }
+  
+  @media ${(props) => props.theme.breakpoints.sm} {
+    padding: 4px 8px;
+    font-size: 11px;
+  }
+`;
+
+export const SecondaryButtonsContainer = styled.div`
+  display: flex;
+  gap: 16px;
+  margin-top: 16px;
+  
+  @media ${(props) => props.theme.breakpoints.sm} {
+    flex-direction: column;
+    gap: 8px;
+    margin-top: 12px;
+  }
+`;
+
+export const SecondaryButton = styled.a`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 12px 20px;
+  background: transparent;
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  border-radius: 50px;
+  font-size: 16px;
+  font-weight: 500;
+  color: rgba(255, 255, 255, 0.85);
+  text-decoration: none;
+  cursor: pointer;
+  transition: all 0.3s ease;
+  
+  &:hover {
+    background: rgba(255, 255, 255, 0.1);
+    border-color: rgba(255, 255, 255, 0.4);
+    color: #fff;
+  }
+  
+  @media ${(props) => props.theme.breakpoints.md} {
+    padding: 10px 16px;
+    font-size: 14px;
+  }
+  
+  @media ${(props) => props.theme.breakpoints.sm} {
+    padding: 10px 16px;
+    font-size: 13px;
+    width: 100%;
+  }
+`;

--- a/src/components/OutcomesStrip/OutcomesStrip.js
+++ b/src/components/OutcomesStrip/OutcomesStrip.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import { useTranslation } from 'next-i18next';
+import {
+  OutcomesContainer,
+  OutcomesList,
+  OutcomesItem,
+  OutcomesIcon
+} from './OutcomesStripStyles';
+
+const OutcomesStrip = () => {
+  const { t } = useTranslation('common');
+
+  return (
+    <OutcomesContainer>
+      <OutcomesList>
+        <OutcomesItem>
+          <OutcomesIcon>📈</OutcomesIcon>
+          {t('outcomes.mau')}
+        </OutcomesItem>
+        <OutcomesItem>
+          <OutcomesIcon>💼</OutcomesIcon>
+          {t('outcomes.portfolio')}
+        </OutcomesItem>
+        <OutcomesItem>
+          <OutcomesIcon>🚀</OutcomesIcon>
+          {t('outcomes.experience')}
+        </OutcomesItem>
+      </OutcomesList>
+    </OutcomesContainer>
+  );
+};
+
+export default OutcomesStrip;

--- a/src/components/OutcomesStrip/OutcomesStripStyles.js
+++ b/src/components/OutcomesStrip/OutcomesStripStyles.js
@@ -1,0 +1,72 @@
+import styled from 'styled-components';
+
+export const OutcomesContainer = styled.div`
+  width: 100%;
+  max-width: 1040px;
+  margin: 0 auto;
+  padding: 24px 48px;
+  
+  @media ${(props) => props.theme.breakpoints.md} {
+    padding: 20px 32px;
+  }
+  
+  @media ${(props) => props.theme.breakpoints.sm} {
+    padding: 16px 16px;
+  }
+`;
+
+export const OutcomesList = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 16px;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 12px;
+  padding: 20px 24px;
+  
+  @media ${(props) => props.theme.breakpoints.md} {
+    gap: 12px;
+    padding: 16px 20px;
+  }
+  
+  @media ${(props) => props.theme.breakpoints.sm} {
+    flex-direction: column;
+    gap: 10px;
+    padding: 14px 16px;
+  }
+`;
+
+export const OutcomesItem = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 16px;
+  font-weight: 500;
+  color: rgba(255, 255, 255, 0.85);
+  padding: 8px 16px;
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: 8px;
+  white-space: nowrap;
+  
+  @media ${(props) => props.theme.breakpoints.md} {
+    font-size: 14px;
+    padding: 6px 12px;
+  }
+  
+  @media ${(props) => props.theme.breakpoints.sm} {
+    font-size: 13px;
+    padding: 8px 12px;
+    white-space: normal;
+    text-align: center;
+    justify-content: center;
+  }
+`;
+
+export const OutcomesIcon = styled.span`
+  font-size: 18px;
+  
+  @media ${(props) => props.theme.breakpoints.sm} {
+    font-size: 16px;
+  }
+`;

--- a/src/components/Projects/Projects.js
+++ b/src/components/Projects/Projects.js
@@ -44,7 +44,7 @@ const containerStyle = {
 // LinkTracker (id: 0) is also discontinued.
 const DISCONTINUED_PROJECT_IDS = [0, 1, 3, 4, 5, 6];
 const SOLD_PROJECT_IDS = [11]; // affiliatecompanies.net
-const FEATURED_PROJECT_IDS = [2, 8, 12, 13, 14]; // lustigedruckshirts.de, print2social, PODB, tierarzt-liste, clipclean
+const FEATURED_PROJECT_IDS = [12, 13, 8, 2]; // PODB, tierarzt-liste, print2social, lustigedruckshirts.de - ClipClean moved to utilities
 
 const Projects = () => {
   const { t, i18n } = useTranslation(['common', 'projects']);

--- a/src/components/Technologies/Technologies.js
+++ b/src/components/Technologies/Technologies.js
@@ -56,6 +56,8 @@ const Technologies = () => {
       <SectionTitle main>{t('technologies.title')}</SectionTitle>
       <SectionText>
         {t('technologies.subtitle')}
+        <br />
+        <span style={{ opacity: 0.9 }}>{t('technologies.subtitleSecondLine')}</span>
       </SectionText>
       <div style={containerStyle}>
         <TechGridContainer>

--- a/src/components/TimeLine/TimeLine.js
+++ b/src/components/TimeLine/TimeLine.js
@@ -26,41 +26,9 @@ import { TimeLineData } from "../../constants/constants";
 
 const TOTAL_CAROUSEL_COUNT = TimeLineData.length;
 
-const calculateAge = (birthDate) => {
-  const today = new Date();
-  const birthDateObj = new Date(birthDate);
-
-  let years = today.getFullYear() - birthDateObj.getFullYear();
-  let months = today.getMonth() - birthDateObj.getMonth();
-  let days = today.getDate() - birthDateObj.getDate();
-  const hours = today.getHours() - birthDateObj.getHours();
-  const minutes = today.getMinutes() - birthDateObj.getMinutes();
-  const seconds = today.getSeconds() - birthDateObj.getSeconds();
-  // If the current day of the month is less than the birth day, subtract one month
-  if (days < 0) {
-    months--;
-    // Calculate the number of days remaining in the previous month
-    const daysInPrevMonth = new Date(
-      today.getFullYear(),
-      today.getMonth(),
-      0
-    ).getDate();
-    days += daysInPrevMonth;
-  }
-
-  // If the current month is less than the birth month, subtract one year
-  if (months < 0) {
-    years--;
-    months += 12;
-  }
-
-  return { years, months, days, hours, minutes, seconds };
-};
-
 const Timeline = () => {
   const { t } = useTranslation('common');
   const [activeItem, setActiveItem] = useState(0);
-  const [age, setAge] = useState(null);
   const carouselRef = useRef();
 
   const scroll = (node, left) => {
@@ -120,17 +88,6 @@ const Timeline = () => {
     };
   }, []);
 
-  useEffect(() => {
-    setAge(calculateAge('1984-10-16'));
-    const interval = setInterval(() => {
-      setAge(calculateAge('1984-10-16'));
-    }, 1000);
-
-    return () => {
-      clearInterval(interval);
-    };
-  }, []);
-
   // Ensure the carousel is properly initialized
   useEffect(() => {
     if (carouselRef.current) {
@@ -166,18 +123,13 @@ const Timeline = () => {
         </div>
         
         <ProfileTextContainer>
-          <ProfileSectionText
-            dangerouslySetInnerHTML={age && {
-              __html: t('about.ageText', {
-                years: age.years,
-                months: age.months,
-                days: age.days,
-                hours: age.hours,
-                minutes: age.minutes,
-                seconds: age.seconds,
-                defaultValue: `Since I've been born ${age.years} years, ${age.months} months, ${age.days} days, ${age.hours} hours, ${age.minutes} minutes, and ${age.seconds} seconds ago, I've managed to accomplish the following:`
-              }),
-            }}/>
+          <ProfileSectionText>
+            {t('about.bioLine1')}
+            <br />
+            {t('about.bioLine2')}
+            <br />
+            {t('about.bioLine3')}
+          </ProfileSectionText>
         </ProfileTextContainer>
       </ProfilePhotoContainer>
       <CarouselContainer ref={carouselRef} onScroll={handleScroll}>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,6 +1,7 @@
 import Acomplishments from '../components/Acomplishments/Acomplishments';
 import BgAnimation from '../components/BackgrooundAnimation/BackgroundAnimation';
 import Hero from '../components/Hero/Hero';
+import OutcomesStrip from '../components/OutcomesStrip/OutcomesStrip';
 import Projects from '../components/Projects/Projects';
 import Testimonials from '../components/Testimonials/Testimonials';
 import Technologies from '../components/Technologies/Technologies';
@@ -19,7 +20,7 @@ const Home = () => {
     "@context": "https://schema.org",
     "@type": "Person",
     "name": "Samir Alibabic",
-    "jobTitle": "Software Engineer & Digital Entrepreneur",
+    "jobTitle": "Software Engineer & Solo Founder",
     "url": "https://www.samiralibabic.com",
     "sameAs": [
       "https://github.com/samiralibabic",
@@ -46,6 +47,7 @@ const Home = () => {
           <Hero />
           <BgAnimation />
         </Section>
+        <OutcomesStrip />
         <Projects />
         <Technologies />
         <Timeline />


### PR DESCRIPTION
Refactor homepage to emphasize a 'solo operator + real products' signal, enhancing trust and credibility by updating hero content, project order, bio, and contact methods.

---
<a href="https://cursor.com/background-agent?bcId=bc-644ce5f6-c583-447b-b04e-efc0b03a6919"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-644ce5f6-c583-447b-b04e-efc0b03a6919"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Modernizes homepage to emphasize solo founder and product outcomes.
> 
> - Updates EN/DE `common.json`: new meta, hero copy (incl. `introSecondLine`, `proofChips`), technology subtitles, replaces `about.ageText` with `bioLine*`, and adds `outcomes`, `contact`, `now` keys
> - Enhances `Hero`: adds proof chips, secondary CTAs; new styles in `HeroStyles`
> - Reworks `Footer`: contact section with `mailto` button and hint list, plus a "Now" section; adds corresponding styles
> - Adds `OutcomesStrip` component and styles; rendered on `pages/index.js`
> - Reorders featured projects in `Projects.js` (moves ClipClean to utilities)
> - Simplifies `Timeline`: removes live age calc, shows static bio lines
> - Updates JSON-LD `jobTitle` on homepage
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dc93214589030c9397f55874df9a95e5d58388e2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->