### PR TITLE
Add Monitor project to portfolio utilities

### DIFF
--- a/public/images/monitor.svg
+++ b/public/images/monitor.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="800" viewBox="0 0 1200 800">
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0%" stop-color="#0f172a" />
+      <stop offset="100%" stop-color="#1e293b" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="800" fill="url(#bg)" />
+  <rect x="160" y="160" width="880" height="440" rx="28" fill="#0b1220" stroke="#38bdf8" stroke-width="8" />
+  <rect x="220" y="220" width="760" height="320" rx="18" fill="#111827" />
+  <path d="M320 480 L420 380 L520 430 L620 320 L720 360 L820 260" fill="none" stroke="#22c55e" stroke-width="12" stroke-linecap="round" stroke-linejoin="round" />
+  <circle cx="320" cy="480" r="8" fill="#22c55e" />
+  <circle cx="420" cy="380" r="8" fill="#22c55e" />
+  <circle cx="520" cy="430" r="8" fill="#22c55e" />
+  <circle cx="620" cy="320" r="8" fill="#22c55e" />
+  <circle cx="720" cy="360" r="8" fill="#22c55e" />
+  <circle cx="820" cy="260" r="8" fill="#22c55e" />
+  <rect x="520" y="610" width="160" height="40" rx="12" fill="#38bdf8" />
+  <rect x="460" y="650" width="280" height="24" rx="12" fill="#1f2937" />
+  <text x="600" y="380" text-anchor="middle" font-family="'Segoe UI', Arial, sans-serif" font-size="56" fill="#e2e8f0" font-weight="600">Monitor</text>
+  <text x="600" y="450" text-anchor="middle" font-family="'Segoe UI', Arial, sans-serif" font-size="28" fill="#94a3b8">Uptime &amp; performance checks</text>
+</svg>

--- a/public/locales/de/projects.json
+++ b/public/locales/de/projects.json
@@ -45,6 +45,9 @@
     },
     "14": {
       "description": "Ein KI-gestützter Audio-Bereinigungsservice, der Füllwörter und peinliche Pausen aus Podcasts und Aufnahmen entfernt."
+    },
+    "15": {
+      "description": "Ein Monitoring-Tool für Verfügbarkeits- und Performance-Prüfungen von Websites und Services."
     }
   }
-} 
+}

--- a/public/locales/en/projects.json
+++ b/public/locales/en/projects.json
@@ -45,6 +45,9 @@
     },
     "14": {
       "description": "An AI-powered audio cleaning service that removes filler words and awkward pauses from podcasts and recordings."
+    },
+    "15": {
+      "description": "A monitoring tool for uptime and performance checks on websites and services."
     }
   }
 } 

--- a/src/constants/constants.js
+++ b/src/constants/constants.js
@@ -88,6 +88,14 @@ export const projects = [
     id: 10,
   },
   {
+    title: 'Monitor',
+    description: 'A monitoring tool for uptime and performance checks on websites and services.',
+    image: '/images/monitor.svg',
+    tags: ['Monitoring', 'Utilities'],
+    visit: 'https://monitor.samiralibabic.com',
+    id: 15,
+  },
+  {
     title: 'Affiliate Companies',
     description: 'Discover the top affiliate programs with excellent earning potential.',
     image: '/images/affiliatecompanies.webp',


### PR DESCRIPTION
### Motivation

- The portfolio was missing the Monitor project entry that should appear in the utilities group next to WebCrawler, and it needs localized descriptions and an image asset. 

### Description

- Added a new `Monitor` project object (id `15`) to the `projects` array in `src/constants/constants.js` with `visit` URL and `image` path. 
- Added a new SVG asset at `public/images/monitor.svg` used as the project image. 
- Added localized descriptions for the Monitor project in `public/locales/en/projects.json` and `public/locales/de/projects.json`. 

### Testing

- Started the dev server with `npm run dev -- --hostname 0.0.0.0 --port 3000`, which compiled and served the app successfully (with non-blocking font/image warnings). 
- Ran a Playwright script to navigate to the local site and capture the Projects > Utilities view; the first run timed out but a subsequent run succeeded and produced `artifacts/monitor-utilities.png`. 
- No unit or integration test suites were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69694eec1ea4832c974feed0ea19f732)