### PR TITLE
Refine 'Build details' footer trigger to an inline link

### DIFF
--- a/public/locales/de/common.json
+++ b/public/locales/de/common.json
@@ -20,7 +20,7 @@
   },
   "navigation": {
     "projects": "Projekte",
-    "technologies": "Technologien",
+    "technologies": "Build details",
     "about": "Über mich",
     "testimonials": "Referenzen",
     "contact": "Kontakt",

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -20,7 +20,7 @@
   },
   "navigation": {
     "projects": "Projects",
-    "technologies": "Technologies",
+    "technologies": "Build details",
     "about": "About",
     "testimonials": "Testimonials",
     "contact": "Contact",

--- a/src/components/Footer/Footer.js
+++ b/src/components/Footer/Footer.js
@@ -3,7 +3,7 @@ import Link from 'next/link';
 import { useTranslation } from 'next-i18next';
 
 import SocialIconsGroup from '../SocialIcons/SocialIcons';
-import { CompanyContainer, FooterWrapper, LinkColumn, LinkItem, LinkList, LinkTitle, Slogan, LegalLinks, LegalNavLink, SocialIconsContainer, ContactButton, ContactHints, ContactHintItem, ContactSection, NowSection, NowText } from './FooterStyles';
+import { BuildDetailsLink, CompanyContainer, FooterWrapper, LinkItem, LinkList, LinkTitle, LegalLinks, LegalNavLink, SocialIconsContainer, ContactButton, ContactHints, ContactHintItem, ContactSection, NowSection, NowText } from './FooterStyles';
 
 const Footer = () => {
   const { t } = useTranslation('common');
@@ -35,7 +35,9 @@ const Footer = () => {
 
       <SocialIconsContainer>
         <CompanyContainer>
-          <Slogan>{t('footer.slogan', 'Innovating one project at a time')}</Slogan>
+          <Link href="#build-details" scroll={false}>
+            <BuildDetailsLink>Build details</BuildDetailsLink>
+          </Link>
         </CompanyContainer>
         <SocialIconsGroup />
       </SocialIconsContainer>

--- a/src/components/Footer/FooterStyles.js
+++ b/src/components/Footer/FooterStyles.js
@@ -90,23 +90,25 @@ export const CompanyContainer = styled.div`
 	}
 `
 
-export const Slogan = styled.p`
-	color: rgba(255, 255, 255, 0.5);
-	min-width: 280px;
+export const BuildDetailsLink = styled(NavLink)`
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+	color: rgba(255, 255, 255, 0.75);
+	font-size: 14px;
 	letter-spacing: 0.02em;
-	font-size: 18px;
-	line-height: 30px;
-	padding: 1rem;
+	padding: 4px 0;
+	border-bottom: 1px solid rgba(255, 255, 255, 0.25);
+	transition: color 0.2s ease, border-color 0.2s ease;
 
-	@media ${props => props.theme.breakpoints.md} {
-		font-size: 16px;
-		line-height: 28px;
+	&:hover {
+		color: #ffffff;
+		border-color: rgba(255, 255, 255, 0.6);
 	}
 
-	@media ${props => props.theme.breakpoints.sm} {
-		line-height: 22px;
-		font-size: 14px;
-		min-width: 100px;
+	&:focus {
+		outline: 2px solid rgba(255, 255, 255, 0.4);
+		outline-offset: 2px;
 	}
 `
 

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -46,7 +46,7 @@ const Header = () => {
         <Link href="#projects" scroll={false}>
           <NavLink>{t('navigation.projects')}</NavLink>
         </Link>
-        <Link href="#tech" scroll={false}>
+        <Link href="#build-details" scroll={false}>
           <NavLink>{t('navigation.technologies')}</NavLink>
         </Link>
         <Link href="#contact" scroll={false}>

--- a/src/components/Technologies/Technologies.js
+++ b/src/components/Technologies/Technologies.js
@@ -1,127 +1,95 @@
-import React from 'react';
-import { DiGoogleCloudPlatform, DiJava, DiReact, DiWordpress } from 'react-icons/di';
-import { useTranslation } from 'next-i18next';
-import { Section, SectionDivider, SectionText, SectionTitle } from '../../styles/GlobalComponents';
-import { TechGridContainer, ListContainer, ListItem, ListParagraph, ListTitle } from './TechnologiesStyles';
-import { BlogCard } from '../Projects/ProjectsStyles';
-import { technologies } from '../../constants/constants';
-
-// Container style for better centering
-const containerStyle = {
-  width: '100%',
-  display: 'flex',
-  justifyContent: 'center'
-};
-
-// Card style to make them narrower
-const cardStyle = {
-  width: '100%',
-  maxWidth: '450px',
-  margin: '0 auto'
-};
-
-// Style for subgroup titles
-const subgroupTitleStyle = {
-  fontSize: '18px',
-  fontWeight: '600',
-  color: '#fff',
-  marginTop: '15px',
-  marginBottom: '8px',
-  textAlign: 'center'
-};
-
-// Style for comma-separated tech list
-const techListStyle = {
-  fontSize: '16px',
-  lineHeight: '24px',
-  color: 'rgba(255, 255, 255, 0.75)',
-  padding: '0 10px 15px',
-  textAlign: 'center'
-};
+import React, { useEffect, useId, useState } from 'react';
+import { Section } from '../../styles/GlobalComponents';
+import {
+  CloseButton,
+  Drawer,
+  DrawerBody,
+  DrawerHeader,
+  DrawerIntro,
+  DrawerList,
+  DrawerListItem,
+  DrawerNote,
+  DrawerTitle,
+  OverlayBackdrop,
+} from './TechnologiesStyles';
 
 const Technologies = () => {
-  const { t } = useTranslation('common');
-  
-  // Translation mapping for subgroup titles
-  const getSubgroupTranslation = (category, subgroup) => {
-    const translationKey = `technologies.${category}Categories.${subgroup}`;
-    // Use the capitalized subgroup name as fallback
-    const fallback = subgroup.charAt(0).toUpperCase() + subgroup.slice(1);
-    return t(translationKey, fallback);
-  };
-  
+  const [isOpen, setIsOpen] = useState(false);
+  const titleId = useId();
+
+  useEffect(() => {
+    const handleHashChange = () => {
+      if (window.location.hash === '#build-details') {
+        setIsOpen(true);
+      }
+    };
+
+    handleHashChange();
+    window.addEventListener('hashchange', handleHashChange);
+
+    return () => {
+      window.removeEventListener('hashchange', handleHashChange);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!isOpen) {
+      if (window.location.hash === '#build-details') {
+        window.history.replaceState({}, document.title, window.location.pathname + window.location.search);
+      }
+      return undefined;
+    }
+
+    const handleKeyDown = (event) => {
+      if (event.key === 'Escape') {
+        setIsOpen(false);
+      }
+    };
+
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    document.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      document.body.style.overflow = previousOverflow;
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [isOpen]);
+
   return (
-    <Section id='tech'>
-      <SectionDivider />
-      <SectionTitle main>{t('technologies.title')}</SectionTitle>
-      <SectionText>
-        {t('technologies.subtitle')}
-        <br />
-        <span style={{ opacity: 0.9 }}>{t('technologies.subtitleSecondLine')}</span>
-      </SectionText>
-      <div style={containerStyle}>
-        <TechGridContainer>
-          <BlogCard style={cardStyle}>
-            <ListContainer>
-              <ListTitle><DiReact size='30' style={{ minWidth: '30px', marginRight: '10px' }} />{t('technologies.frontend', 'Front-End')}</ListTitle>
-              
-              {Object.entries(technologies.frontEnd).map(([subgroup, techs]) => (
-                <React.Fragment key={subgroup}>
-                  <div style={subgroupTitleStyle}>{getSubgroupTranslation('frontend', subgroup)}</div>
-                  <div style={techListStyle}>
-                    {techs.join(', ')}
-                  </div>
-                </React.Fragment>
-              ))}
-            </ListContainer>
-          </BlogCard>
-          
-          <BlogCard style={cardStyle}>
-            <ListContainer>
-              <ListTitle><DiJava size='30' style={{ minWidth: '30px', marginRight: '10px' }} />{t('technologies.backend', 'Back-End')}</ListTitle>
-              
-              {Object.entries(technologies.backEnd).map(([subgroup, techs]) => (
-                <React.Fragment key={subgroup}>
-                  <div style={subgroupTitleStyle}>{getSubgroupTranslation('backend', subgroup)}</div>
-                  <div style={techListStyle}>
-                    {techs.join(', ')}
-                  </div>
-                </React.Fragment>
-              ))}
-            </ListContainer>
-          </BlogCard>
-          
-          <BlogCard style={cardStyle}>
-            <ListContainer>
-              <ListTitle><DiGoogleCloudPlatform size='30' style={{ minWidth: '30px', marginRight: '10px' }} />{t('technologies.devops', 'DevOps')}</ListTitle>
-              
-              {Object.entries(technologies.devOps).map(([subgroup, techs]) => (
-                <React.Fragment key={subgroup}>
-                  <div style={subgroupTitleStyle}>{getSubgroupTranslation('devops', subgroup)}</div>
-                  <div style={techListStyle}>
-                    {techs.join(', ')}
-                  </div>
-                </React.Fragment>
-              ))}
-            </ListContainer>
-          </BlogCard>
-          
-          <BlogCard style={cardStyle}>
-            <ListContainer>
-              <ListTitle><DiWordpress size='30' style={{ minWidth: '30px', marginRight: '10px' }} />{t('technologies.additional', 'Additional Skills and Practices')}</ListTitle>
-              
-              {Object.entries(technologies.additionalSkills).map(([subgroup, techs]) => (
-                <React.Fragment key={subgroup}>
-                  <div style={subgroupTitleStyle}>{getSubgroupTranslation('additional', subgroup)}</div>
-                  <div style={techListStyle}>
-                    {techs.join(', ')}
-                  </div>
-                </React.Fragment>
-              ))}
-            </ListContainer>
-          </BlogCard>
-        </TechGridContainer>
-      </div>
+    <Section id="build-details" nopadding>
+      {isOpen && (
+        <OverlayBackdrop onClick={() => setIsOpen(false)}>
+          <Drawer
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby={titleId}
+            onClick={(event) => event.stopPropagation()}
+          >
+            <DrawerHeader>
+              <DrawerTitle id={titleId}>Build details</DrawerTitle>
+              <CloseButton type="button" onClick={() => setIsOpen(false)} aria-label="Close build details">
+                ×
+              </CloseButton>
+            </DrawerHeader>
+            <DrawerBody>
+              <DrawerIntro>
+                I build and run digital products end-to-end — from idea to production. I’m not tied to a
+                specific tech stack; tools are chosen based on what the problem needs.
+              </DrawerIntro>
+              <DrawerList>
+                <DrawerListItem>What I do: plan, build, operate, measure, improve</DrawerListItem>
+                <DrawerListItem>How I work: pragmatic, fast, focused on outcomes</DrawerListItem>
+                <DrawerListItem>Usually today: web projects (often TypeScript)</DrawerListItem>
+                <DrawerListItem>Also: mobile/desktop/embedded when it’s the right interface</DrawerListItem>
+              </DrawerList>
+              <DrawerNote>
+                Implementation can be AI-assisted — responsibility, decisions, and review are mine.
+              </DrawerNote>
+            </DrawerBody>
+          </Drawer>
+        </OverlayBackdrop>
+      )}
     </Section>
   );
 };

--- a/src/components/Technologies/TechnologiesStyles.js
+++ b/src/components/Technologies/TechnologiesStyles.js
@@ -1,166 +1,99 @@
-import styled from 'styled-components'
+import styled from 'styled-components';
 
-export const TechGridContainer = styled.div`
-  display: grid;
-  grid-template-columns: repeat(2, 1fr); /* Always show 2 columns on desktop */
-  gap: 3rem; /* Increased gap to match projects section */
-  padding: 3rem;
-  max-width: 1000px; /* Limit the overall width */
-  width: 100%;
+export const OverlayBackdrop = styled.div`
+  position: fixed;
+  inset: 0;
+  background: rgba(8, 12, 20, 0.72);
+  backdrop-filter: blur(4px);
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
 
   @media ${(props) => props.theme.breakpoints.md} {
-    grid-template-columns: repeat(2, 1fr); /* Keep 2 columns on tablet */
-    gap: 2rem;
+    align-items: flex-end;
     padding: 0;
-  }
-
-  @media ${(props) => props.theme.breakpoints.sm} {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    padding: 0;
-    width: 100%;
-    gap: 2rem; /* Reduced gap for mobile */
   }
 `;
 
-export const ImageContainer = styled.div`
-  text-align: center;
-  background-image: radial-gradient(50% 50% at 50% 50%, rgba(79, 108, 176, 0.25) 53.8%, rgba(79, 108, 176, 0) 100%);
-  width: 100%;
-  padding: 60px;
-  margin-top: 48px;
+export const Drawer = styled.div`
+  background: ${(props) => props.theme.colors.background1};
+  border-radius: 16px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  width: min(560px, 92vw);
+  max-height: 80vh;
+  overflow-y: auto;
+  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.5);
+  padding: 24px;
+
+  @media ${(props) => props.theme.breakpoints.md} {
+    width: 100%;
+    border-radius: 18px 18px 0 0;
+    max-height: 75vh;
+  }
+`;
+
+export const DrawerHeader = styled.div`
   display: flex;
-  flex-direction: column;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 16px;
+`;
+
+export const DrawerTitle = styled.h3`
+  font-size: 22px;
+  line-height: 28px;
+  font-weight: 700;
+  color: #ffffff;
+  margin: 0;
+`;
+
+export const CloseButton = styled.button`
+  border: none;
+  background: rgba(255, 255, 255, 0.08);
+  color: #ffffff;
+  width: 32px;
+  height: 32px;
+  border-radius: 999px;
+  cursor: pointer;
+  display: flex;
   align-items: center;
   justify-content: center;
+  font-size: 18px;
+  transition: background 0.2s ease;
 
-  @media ${props => props.theme.breakpoints.lg} {
-    background-image: none;
-    padding: 0;
-    margin-top: 40px;
-  }
-  @media ${props => props.theme.breakpoints.md} {
-    background-image: none;
-    padding: 0;
-    margin-top: 16px;
-  }
-`
-
-export const MainImage = styled.img`
-  width: 100%;
-`
-
-export const List = styled.ul`
-  list-style-type: none;
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: 40px;
-  margin: 3rem 0;
-  
-  @media ${props => props.theme.breakpoints.lg}{
-    margin: 64px 0;
+  &:hover {
+    background: rgba(255, 255, 255, 0.16);
   }
 
-  @media ${props => props.theme.breakpoints.md}{
-    margin: 64px 0;
-    gap: 24px
+  &:focus {
+    outline: 2px solid rgba(255, 255, 255, 0.4);
+    outline-offset: 2px;
   }
-  
-  @media ${props => props.theme.breakpoints.sm}{
-    display: flex;
-    flex-direction: column;
-    margin: 32px 0;
-  }
-`
+`;
 
-export const ListContainer = styled.div`
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  padding: 10px 15px 20px;
-  width: 100%;
-
-  @media ${props => props.theme.breakpoints.sm}{
-    padding: 10px 10px 15px;
-  }
-`
-
-export const ListTitle = styled.h4`
-  display: flex;
-  padding: 15px 0;
-  align-items: center;
-  font-weight: 700;
-  font-size: 24px;
-  line-height: 28px;
-  letter-spacing: 0.02em;
-  color: #FFFFFF;
-  margin-bottom: 10px;
-
-  @media ${props => props.theme.breakpoints.md}{
-    font-size: 22px;
-    line-height: 26px;
-    padding: 12px 0;
-  }
-
-  @media ${props => props.theme.breakpoints.sm}{
-    font-size: 20px;
-    line-height: 24px;
-    letter-spacing: 0.02em;
-    margin-bottom: 8px;
-    padding: 10px 0;
-  }
-`
-
-export const ListParagraph = styled.p`
+export const DrawerBody = styled.div`
+  color: rgba(255, 255, 255, 0.78);
   font-size: 16px;
-  line-height: 24px;
-  color: rgba(255, 255, 255, 0.75);
-  margin: 0;
+  line-height: 26px;
+`;
 
-  @media ${props => props.theme.breakpoints.md}{
-    font-size: 15px;
-    line-height: 22px;
-  }
+export const DrawerIntro = styled.p`
+  margin: 0 0 16px 0;
+`;
 
-  @media ${props => props.theme.breakpoints.sm}{
-    font-size: 14px;
-    line-height: 20px;
-  }
-`
+export const DrawerList = styled.ul`
+  margin: 0 0 16px 18px;
+  padding: 0;
+`;
 
-export const ListItem = styled.li`
-  max-width: 100%;
-  display: flex;
-  flex-direction: column;
-  margin-bottom: 8px;
-  padding: 0 10px;
-
-  @media ${props => props.theme.breakpoints.md}{
-    margin-bottom: 6px;
-  }
-
-  @media ${props => props.theme.breakpoints.sm}{
-    margin-bottom: 4px;
-    flex-direction: row;
-  }
-`
-
-export const ListIcon = styled.img`
-  display: block;
-  width: 48px;
-  height: 48px;
+export const DrawerListItem = styled.li`
   margin-bottom: 10px;
-  
-  @media ${props => props.theme.breakpoints.md}{
-    width: 40px;
-    height: 40px;
-    margin-bottom: 8px;
-  }
+`;
 
-  @media ${props => props.theme.breakpoints.sm}{
-    width: 32px;
-    height: 32px;
-    margin-bottom: 0px;
-  }
-`
+export const DrawerNote = styled.p`
+  margin: 0;
+  font-size: 14px;
+  color: rgba(255, 255, 255, 0.6);
+`;


### PR DESCRIPTION
### Motivation
- Make the footer "Build details" trigger fit seamlessly into the site instead of using a pill-style button. 
- Keep the previously-added build-details drawer accessible from both the header nav and the footer link.

### Description
- Replace footer slogan with a subtle inline `BuildDetailsLink` and remove the arrow glyph in `src/components/Footer/Footer.js` and `src/components/Footer/FooterStyles.js` to align with site styling. 
- Ensure header nav points to the same `#build-details` anchor in `src/components/Header/Header.js` and update locale labels in `public/locales/*/common.json`. 
- Render a modal-style drawer for build details in `src/components/Technologies/Technologies.js` that opens when `#build-details` is present or when the footer link is clicked, includes an overlay, header, close button, Escape-key handling, and body-scroll prevention. 
- Add new drawer and overlay styled components in `src/components/Technologies/TechnologiesStyles.js` to support the dialog presentation and accessible controls.

### Testing
- Started the dev server with `npm run dev`; compilation completed with font-download fallbacks and a non-boolean attribute warning but no runtime failures. 
- Ran a Playwright script that navigated to the page and clicked the footer `Build details` link; the script succeeded and produced `artifacts/build-details-footer-link.png` showing the drawer open state.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696968e2180c832cbb6a6b638899c5ca)