### PR TITLE
Remove header "Build details" link and make footer open the build-details drawer

### DIFF
--- a/src/components/Footer/Footer.js
+++ b/src/components/Footer/Footer.js
@@ -7,6 +7,16 @@ import { BuildDetailsLink, CompanyContainer, FooterWrapper, LinkItem, LinkList, 
 
 const Footer = () => {
   const { t } = useTranslation('common');
+
+  const handleBuildDetailsClick = () => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    const nextUrl = `${window.location.pathname}${window.location.search}#build-details`;
+    window.history.replaceState({}, document.title, nextUrl);
+    window.dispatchEvent(new CustomEvent('build-details:open'));
+  };
   
   return (
     <FooterWrapper>
@@ -35,9 +45,9 @@ const Footer = () => {
 
       <SocialIconsContainer>
         <CompanyContainer>
-          <Link href="#build-details" scroll={false}>
-            <BuildDetailsLink>Build details</BuildDetailsLink>
-          </Link>
+          <BuildDetailsLink as="button" type="button" onClick={handleBuildDetailsClick}>
+            Build details
+          </BuildDetailsLink>
         </CompanyContainer>
         <SocialIconsGroup />
       </SocialIconsContainer>

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -46,9 +46,6 @@ const Header = () => {
         <Link href="#projects" scroll={false}>
           <NavLink>{t('navigation.projects')}</NavLink>
         </Link>
-        <Link href="#build-details" scroll={false}>
-          <NavLink>{t('navigation.technologies')}</NavLink>
-        </Link>
         <Link href="#contact" scroll={false}>
           <NavLink>{t('navigation.contact')}</NavLink>
         </Link>

--- a/src/components/Technologies/Technologies.js
+++ b/src/components/Technologies/Technologies.js
@@ -33,6 +33,18 @@ const Technologies = () => {
   }, []);
 
   useEffect(() => {
+    const handleOpenRequest = () => {
+      setIsOpen(true);
+    };
+
+    window.addEventListener('build-details:open', handleOpenRequest);
+
+    return () => {
+      window.removeEventListener('build-details:open', handleOpenRequest);
+    };
+  }, []);
+
+  useEffect(() => {
     if (!isOpen) {
       if (window.location.hash === '#build-details') {
         window.history.replaceState({}, document.title, window.location.pathname + window.location.search);


### PR DESCRIPTION
### Motivation
- The top navigation should not include a duplicate "Build details" entry so the control only appears in the footer.
- The footer control should open the actual drawer/modal instead of scrolling to the about section when clicked.
- Ensure the drawer responds to an explicit open request from the footer without causing a page scroll.

### Description
- Removed the `#build-details` link from the header navigation in `src/components/Header/Header.js` so it no longer appears in the top menu.
- Replaced the footer anchor with a button in `src/components/Footer/Footer.js` and added `handleBuildDetailsClick` which updates the URL hash via `history.replaceState` and dispatches a `CustomEvent('build-details:open')`.
- Added an event listener in `src/components/Technologies/Technologies.js` to handle the `build-details:open` event and open the drawer (keeps the existing hashchange handling intact).

### Testing
- Started the dev server with `npm run dev` and the application compiled and served successfully.
- Attempted an end-to-end check with Playwright to click the footer "Build details" and assert the dialog opened, but the Playwright run failed due to a Chromium `TargetClosedError` / crash, preventing automated screenshot verification.
- No unit tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69697121bd90832c8d5b841f640a6ee1)