### PR TITLE
Replace Twitter icon with X

### DIFF
--- a/src/components/SocialIcons/SocialIcons.js
+++ b/src/components/SocialIcons/SocialIcons.js
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
-import { AiFillGithub, AiFillTwitterCircle, AiFillLinkedin } from 'react-icons/ai';
+import { AiFillGithub, AiFillLinkedin } from 'react-icons/ai';
 import { FaMastodon } from 'react-icons/fa';
-import { FaBluesky } from 'react-icons/fa6';
+import { FaBluesky, FaXTwitter } from 'react-icons/fa6';
 import { SiBluesky } from 'react-icons/si';
 
 import { SocialIconsContainer, SocialIcon } from './SocialIconsStyles';
@@ -34,8 +34,8 @@ const SocialIconsGroup = () => {
       <SocialIcon href='https://www.linkedin.com/in/samiralibabic/' target='_blank' rel='noopener noreferrer' aria-label='Connect with me on LinkedIn'>
         <AiFillLinkedin size={iconSize} />
       </SocialIcon>
-      <SocialIcon href='https://twitter.com/samiralibabic' target='_blank' rel='noopener noreferrer' aria-label='Follow me on Twitter'>
-        <AiFillTwitterCircle size={iconSize} />
+      <SocialIcon href='https://twitter.com/samiralibabic' target='_blank' rel='noopener noreferrer' aria-label='Follow me on X'>
+        <FaXTwitter size={iconSize} />
       </SocialIcon>
       <SocialIcon href='https://bsky.app/profile/samiralibabic.bsky.social' target='_blank' rel='noopener noreferrer' aria-label='Follow me on Bluesky'>
         <SiBluesky size={iconSize} />


### PR DESCRIPTION
### Motivation
- Update the social link icon to the X glyph to reflect the platform rebrand and keep the site icons current.

### Description
- Replace the `AiFillTwitterCircle` import with `FaXTwitter` from `react-icons/fa6`, swap the JSX node from `<AiFillTwitterCircle />` to `<FaXTwitter />`, and update the aria label to `Follow me on X` in `src/components/SocialIcons/SocialIcons.js`.

### Testing
- Started the dev server with `npm run dev` successfully, attempted a Playwright screenshot which failed due to a Chromium crash (SIGSEGV), and no automated unit tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696971ed834c832cbfeffc794e1e05d8)