### PR TITLE
Replace 'Projects' with 'Products' in locales and UI copy

### DIFF
--- a/public/locales/de/common.json
+++ b/public/locales/de/common.json
@@ -19,7 +19,7 @@
     }
   },
   "navigation": {
-    "projects": "Projekte",
+    "projects": "Produkte",
     "technologies": "Build details",
     "about": "Über mich",
     "testimonials": "Referenzen",
@@ -30,13 +30,13 @@
     "social": "Soziale Medien"
   },
   "projects": {
-    "title": "Projekte",
+    "title": "Produkte",
     "subtitle": "Sehen Sie sich einige meiner neuesten Arbeiten an",
     "visit": "Besuchen",
     "discontinued": "EINGESTELLT",
     "sold": "AKQUIRIERT",
-    "showMore": "Mehr Projekte anzeigen",
-    "showLess": "Weniger Projekte anzeigen",
+    "showMore": "Mehr Produkte anzeigen",
+    "showLess": "Weniger Produkte anzeigen",
     "utilities": "Tools",
     "inactive": "Inaktiv"
   },
@@ -112,7 +112,7 @@
     "privacy": "Datenschutzerklärung",
     "legal": "Impressum",
     "email": "E-Mail",
-    "slogan": "Innovation, ein Projekt nach dem anderen"
+    "slogan": "Innovation, ein Produkt nach dem anderen"
   },
   "language": {
     "en": "Englisch",
@@ -120,7 +120,7 @@
   },
   "acomplishments": {
     "title": "Erfolge",
-    "projects": "Open Source Projekte",
+    "projects": "Open Source Produkte",
     "students": "Studenten",
     "followers": "Github Follower",
     "stars": "Github Sterne"

--- a/public/locales/de/projects.json
+++ b/public/locales/de/projects.json
@@ -1,6 +1,6 @@
 {
   "projects": {
-    "title": "Projekte",
+    "title": "Produkte",
     "0": {
       "description": "Eine Plattform zum Organisieren, Verfolgen und Analysieren der Leistung geteilter Links."
     },
@@ -29,7 +29,7 @@
       "description": "Ein KI-gesteuerter Social-Media-Manager für Print-On-Demand-Unternehmen."
     },
     "9": {
-      "description": "Eine Nischen-Website mit lustigen Sprüchen und Witzen, die Traffic zu anderen Projekten lenkt."
+      "description": "Eine Nischen-Website mit lustigen Sprüchen und Witzen, die Traffic zu anderen Produkten lenkt."
     },
     "10": {
       "description": "Ein Web-Crawler zum Sammeln externer Links von beliebigen Seiten oder ganzen Domains."

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -19,7 +19,7 @@
     }
   },
   "navigation": {
-    "projects": "Projects",
+    "projects": "Products",
     "technologies": "Build details",
     "about": "About",
     "testimonials": "Testimonials",
@@ -30,13 +30,13 @@
     "social": "Social Media"
   },
   "projects": {
-    "title": "Projects",
+    "title": "Products",
     "subtitle": "Check out some of my recent work",
     "visit": "Visit",
     "discontinued": "DISCONTINUED",
     "sold": "ACQUIRED",
-    "showMore": "Show more projects",
-    "showLess": "Show fewer projects",
+    "showMore": "Show more products",
+    "showLess": "Show fewer products",
     "utilities": "Utilities",
     "inactive": "Inactive"
   },
@@ -112,7 +112,7 @@
     "privacy": "Privacy Policy",
     "legal": "Legal Notice",
     "email": "E-Mail",
-    "slogan": "Innovating one project at a time"
+    "slogan": "Innovating one product at a time"
   },
   "language": {
     "en": "English",
@@ -120,7 +120,7 @@
   },
   "acomplishments": {
     "title": "Acomplishments",
-    "projects": "Open Source Projects",
+    "projects": "Open Source Products",
     "students": "Students",
     "followers": "Github Followers",
     "stars": "Github Stars"

--- a/public/locales/en/projects.json
+++ b/public/locales/en/projects.json
@@ -1,6 +1,6 @@
 {
   "projects": {
-    "title": "Projects",
+    "title": "Products",
     "0": {
       "description": "A platform to organize, track, and analyze the performance of shared links."
     },

--- a/src/components/Technologies/Technologies.js
+++ b/src/components/Technologies/Technologies.js
@@ -80,7 +80,7 @@ const Technologies = () => {
               <DrawerList>
                 <DrawerListItem>What I do: plan, build, operate, measure, improve</DrawerListItem>
                 <DrawerListItem>How I work: pragmatic, fast, focused on outcomes</DrawerListItem>
-                <DrawerListItem>Usually today: web projects (often TypeScript)</DrawerListItem>
+                <DrawerListItem>Usually today: web products (often TypeScript)</DrawerListItem>
                 <DrawerListItem>Also: mobile/desktop/embedded when it’s the right interface</DrawerListItem>
               </DrawerList>
               <DrawerNote>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -32,9 +32,9 @@ const Home = () => {
     <>
       <Head>
         <title>{t('meta.title', { defaultValue: 'Samir Alibabic - Software Engineer & Digital Entrepreneur' })}</title>
-        <meta name="description" content={t('meta.description', { defaultValue: 'Portfolio of Samir Alibabic - Showcasing projects and skills in software engineering, indie hacking, and entrepreneurship.' })} />
+        <meta name="description" content={t('meta.description', { defaultValue: 'Portfolio of Samir Alibabic - Showcasing products and skills in software engineering, indie hacking, and entrepreneurship.' })} />
         <meta property="og:title" content={t('meta.title', { defaultValue: 'Samir Alibabic - Software Engineer & Digital Entrepreneur' })} />
-        <meta property="og:description" content={t('meta.description', { defaultValue: 'Portfolio of Samir Alibabic - Showcasing projects and skills in software engineering, indie hacking, and entrepreneurship.' })} />
+        <meta property="og:description" content={t('meta.description', { defaultValue: 'Portfolio of Samir Alibabic - Showcasing products and skills in software engineering, indie hacking, and entrepreneurship.' })} />
         <meta property="og:image" content="https://www.samiralibabic.com/og-image.jpg" />
         <meta property="og:url" content="https://www.samiralibabic.com" />
         <meta name="twitter:card" content="summary_large_image" />


### PR DESCRIPTION
### Motivation
- Replace all user-facing occurrences of “Projects/Projekte” with “Products/Produkte” so the site reads as more business-oriented.

### Description
- Updated English locale files `public/locales/en/common.json` and `public/locales/en/projects.json` to use "Products" and adjusted related phrases.
- Updated German locale files `public/locales/de/common.json` and `public/locales/de/projects.json` to use "Produkte" and adjusted related phrases.
- Updated UI copy in `src/components/Technologies/Technologies.js` and meta description defaults in `src/pages/index.js` to reference "products" instead of "projects".
- These are copy-only changes with no functional or API modifications.

### Testing
- Ran the dev server with `npm run dev`, which compiled successfully though it emitted non-fatal warnings about Google Fonts and a non-boolean attribute.
- Captured a homepage screenshot via Playwright which produced `artifacts/products-home.png` and the server responded with `GET / 200`.
- No automated unit or integration tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696971b9731c832c81ef5446d343153d)