### PR TITLE
Polish build details button styling

### DIFF
--- a/src/components/Footer/FooterStyles.js
+++ b/src/components/Footer/FooterStyles.js
@@ -98,7 +98,14 @@ export const BuildDetailsLink = styled(NavLink)`
 	font-size: 14px;
 	letter-spacing: 0.02em;
 	padding: 4px 0;
+	background: transparent;
+	border: 0;
 	border-bottom: 1px solid rgba(255, 255, 255, 0.25);
+	border-radius: 0;
+	cursor: pointer;
+	font-family: inherit;
+	appearance: none;
+	-webkit-appearance: none;
 	transition: color 0.2s ease, border-color 0.2s ease;
 
 	&:hover {


### PR DESCRIPTION
### Motivation
- Normalize the footer "Build details" control so it doesn't show default button chrome and matches the surrounding link styling across devices.

### Description
- Update `BuildDetailsLink` in `src/components/Footer/FooterStyles.js` to add `background: transparent`, `border: 0`, `border-radius: 0`, `cursor: pointer`, `font-family: inherit`, and `appearance: none`/`-webkit-appearance: none` to remove native button styling while keeping the existing bottom border and hover/focus rules.
- Change is strictly presentational and preserves the existing hover and focus outlines for accessibility.

### Testing
- Ran the app with `npm run dev` and the project compiled successfully (Next dev server started, some Google Fonts warnings only). 
- Captured a visual regression screenshot using a Playwright script saved to `artifacts/footer-build-details.png` to verify the footer appearance visually.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696972b9e680832ca901ef873f270fc9)