### PR TITLE
Refine scroll-to-top button styling and positioning

### DIFF
--- a/src/layout/LayoutStyles.js
+++ b/src/layout/LayoutStyles.js
@@ -8,11 +8,27 @@ margin: auto;
 `;
 
 export const ScrollToTopStyled = styled(ScrollToTop)`
-    right: 10px;
-    bottom: 80px;
-    width: 30px;
-    height: 30px;
-    display: 'flex';
-    justifyContent: 'center';
-    alignItems: 'center'
-`
+    right: calc(20px + env(safe-area-inset-right)) !important;
+    bottom: calc(24px + env(safe-area-inset-bottom)) !important;
+    width: 44px !important;
+    height: 44px !important;
+    border-radius: 14px !important;
+    background: linear-gradient(135deg, rgba(129, 69, 236, 0.95), rgba(33, 169, 197, 0.95)) !important;
+    box-shadow: 0 12px 30px rgba(6, 12, 26, 0.55), 0 2px 10px rgba(40, 67, 117, 0.35) !important;
+    border: 1px solid rgba(255, 255, 255, 0.18) !important;
+    display: flex !important;
+    align-items: center !important;
+    justify-content: center !important;
+    color: #f7f8ff !important;
+    transition: transform 0.2s ease, box-shadow 0.2s ease, opacity 0.2s ease !important;
+
+    &:hover {
+        transform: translateY(-2px) scale(1.03);
+        box-shadow: 0 16px 32px rgba(6, 12, 26, 0.65), 0 4px 12px rgba(40, 67, 117, 0.45) !important;
+    }
+
+    svg {
+        width: 18px;
+        height: 18px;
+    }
+`;


### PR DESCRIPTION
### Motivation
- Improve the scroll-to-top control's visibility, touch target, and alignment on modern devices by updating size, visual treatment, and safe-area awareness.

### Description
- Restyled the `ScrollToTop` component via `src/layout/LayoutStyles.js` to use `right: calc(20px + env(safe-area-inset-right))` and `bottom: calc(24px + env(safe-area-inset-bottom))` for safe-area-aware positioning.
- Increased control size to `44px`, added rounded corners, a gradient background, refined box-shadow and border, hover transform, and tightened `svg` icon sizing to improve appearance and affordance.
- Applied `!important` to key rules to ensure the wrapper from `react-scroll-to-top` is overridden for consistent rendering.

### Testing
- Started the dev server with `npm run dev` and the app compiled and served the homepage (HTTP 200) despite Google Fonts fetch warnings, which fell back to local fonts.
- Executed a Playwright script that navigated to the page, scrolled to the bottom, and captured a screenshot at `artifacts/scroll-to-top.png`, which completed successfully.
- Observed non-blocking console warnings about a non-boolean `center` attribute and font download failures, but these did not prevent the visual verification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696974445950832cad316feb3b7cb30b)