### PR TITLE
Localize build details string and wire i18n in footer & drawer

### DIFF
--- a/public/locales/de/common.json
+++ b/public/locales/de/common.json
@@ -20,7 +20,7 @@
   },
   "navigation": {
     "projects": "Produkte",
-    "technologies": "Build details",
+    "technologies": "Technische Details",
     "about": "Über mich",
     "testimonials": "Referenzen",
     "contact": "Kontakt",
@@ -39,6 +39,10 @@
     "showLess": "Weniger Produkte anzeigen",
     "utilities": "Tools",
     "inactive": "Inaktiv"
+  },
+  "buildDetails": {
+    "title": "Technische Details",
+    "close": "Technische Details schließen"
   },
   "technologies": {
     "title": "Technologien",

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -40,6 +40,10 @@
     "utilities": "Utilities",
     "inactive": "Inactive"
   },
+  "buildDetails": {
+    "title": "Build details",
+    "close": "Close build details"
+  },
   "technologies": {
     "title": "Technologies",
     "subtitle": "I use the right tool for the job — with a focus on speed, reliability, and measurable outcomes.",

--- a/src/components/Footer/Footer.js
+++ b/src/components/Footer/Footer.js
@@ -46,7 +46,7 @@ const Footer = () => {
       <SocialIconsContainer>
         <CompanyContainer>
           <BuildDetailsLink as="button" type="button" onClick={handleBuildDetailsClick}>
-            Build details
+            {t('buildDetails.title', 'Build details')}
           </BuildDetailsLink>
         </CompanyContainer>
         <SocialIconsGroup />

--- a/src/components/Technologies/Technologies.js
+++ b/src/components/Technologies/Technologies.js
@@ -1,4 +1,5 @@
 import React, { useEffect, useId, useState } from 'react';
+import { useTranslation } from 'next-i18next';
 import { Section } from '../../styles/GlobalComponents';
 import {
   CloseButton,
@@ -16,6 +17,7 @@ import {
 const Technologies = () => {
   const [isOpen, setIsOpen] = useState(false);
   const titleId = useId();
+  const { t } = useTranslation('common');
 
   useEffect(() => {
     const handleHashChange = () => {
@@ -79,8 +81,12 @@ const Technologies = () => {
             onClick={(event) => event.stopPropagation()}
           >
             <DrawerHeader>
-              <DrawerTitle id={titleId}>Build details</DrawerTitle>
-              <CloseButton type="button" onClick={() => setIsOpen(false)} aria-label="Close build details">
+              <DrawerTitle id={titleId}>{t('buildDetails.title', 'Build details')}</DrawerTitle>
+              <CloseButton
+                type="button"
+                onClick={() => setIsOpen(false)}
+                aria-label={t('buildDetails.close', 'Close build details')}
+              >
                 ×
               </CloseButton>
             </DrawerHeader>


### PR DESCRIPTION
### Motivation
- Make the "Build details" label and the drawer close aria-label localizable and provide a native German translation.

### Description
- Add `buildDetails.title` and `buildDetails.close` keys to `public/locales/en/common.json` and `public/locales/de/common.json` and change the German navigation label to `"Technische Details"`.
- Wire `useTranslation('common')` into `src/components/Technologies/Technologies.js` and replace the static drawer title and close aria-label with `t('buildDetails.title', ...)` and `t('buildDetails.close', ...)`.
- Replace the static `Build details` link text in `src/components/Footer/Footer.js` with `t('buildDetails.title', ...)` so the footer button is localized.

### Testing
- Started the dev server with `npm run dev` and Next compiled (font download failed with fallback but the app compiled successfully).
- Ran a Playwright script to open `http://127.0.0.1:3000/de`, scroll and capture a screenshot which produced `artifacts/build-details-de.png` confirming the localized UI renders.
- No automated unit tests were added or run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969769bcfb0832cadba48b7b7291edf)