### PR TITLE
Update founder phrasing to "Tech Founder" / "Digital-Unternehmer" in locales

### DIFF
--- a/public/locales/de/common.json
+++ b/public/locales/de/common.json
@@ -1,10 +1,10 @@
 {
   "meta": {
-    "title": "Samir Alibabic - Software-Ingenieur & Solo-Unternehmer",
+    "title": "Samir Alibabic - Software-Ingenieur & Digital-Unternehmer",
     "description": "Ich baue und betreibe Software-Produkte end-to-end – von Code & Daten bis Distribution. Fokus: organisches Wachstum (SEO/Content/Community) und klare, messbare Systeme."
   },
   "hero": {
-    "title": "Software-Ingenieur & Solo-Unternehmer",
+    "title": "Software-Ingenieur & Digital-Unternehmer",
     "intro": "Ich baue und betreibe Software-Produkte end-to-end – von Code & Daten bis Distribution.",
     "introSecondLine": "Fokus: organisches Wachstum (SEO/Content/Community) und klare, messbare Systeme.",
     "contact": "Kontakt",
@@ -12,7 +12,7 @@
     "readBlog": "Blog lesen",
     "proofChips": {
       "mau": "4.2k+ MAU über aktive Produkte",
-      "solo": "Solo seit 2024",
+      "solo": "Digital-Unternehmer seit 2024",
       "valtech": "Valtech (2016–2022)",
       "germany": "Deutschland",
       "since": "Seit 2009 in Software"
@@ -94,7 +94,7 @@
   "about": {
     "title": "Über Mich",
     "subtitle": "Mein Hintergrund und meine Reise",
-    "bioLine1": "Ich entwickle seit 2009 Software und baue seit 2024 Produkte als Solo-Unternehmer.",
+    "bioLine1": "Ich entwickle seit 2009 Software und baue seit 2024 Produkte als Digital-Unternehmer.",
     "bioLine2": "Davor: Software Engineer bei Valtech (2016–2022).",
     "bioLine3": "Heute: organisches Wachstum, klare Systeme und Produkte mit eigener Distribution."
   },
@@ -106,7 +106,7 @@
     "title": "Ausgewählte Ergebnisse",
     "mau": "4.2k+ MAU über aktive Produkte",
     "portfolio": "Portfolio: Software-Produkte, Verzeichnisse & Tools",
-    "experience": "Solo seit 2024 · Valtech 2016–2022"
+    "experience": "Digital-Unternehmer seit 2024 · Valtech 2016–2022"
   },
   "contact": {
     "sendEmail": "E-Mail senden",

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -1,10 +1,10 @@
 {
   "meta": {
-    "title": "Samir Alibabic - Software Engineer & Solo Founder",
+    "title": "Samir Alibabic - Software Engineer & Tech Founder",
     "description": "I build and operate software products end-to-end — from code & data to distribution. Focus: organic growth (SEO/content/community) and clear, measurable systems."
   },
   "hero": {
-    "title": "Software Engineer & Solo Founder",
+    "title": "Software Engineer & Tech Founder",
     "intro": "I build and operate software products end-to-end — from code & data to distribution.",
     "introSecondLine": "Focus: organic growth (SEO/content/community) and clear, measurable systems.",
     "contact": "Contact",
@@ -12,7 +12,7 @@
     "readBlog": "Read the blog",
     "proofChips": {
       "mau": "4.2k+ MAU across active products",
-      "solo": "Solo since 2024",
+      "solo": "Tech founder since 2024",
       "valtech": "Valtech (2016–2022)",
       "germany": "Germany",
       "since": "Building since 2009"
@@ -94,7 +94,7 @@
   "about": {
     "title": "About Me",
     "subtitle": "My background and journey",
-    "bioLine1": "I've been building software since 2009 and have been operating products as a solo founder since 2024.",
+    "bioLine1": "I've been building software since 2009 and have been operating products as a tech founder since 2024.",
     "bioLine2": "Previously: Software Engineer at Valtech (2016–2022).",
     "bioLine3": "Today: organic growth, clear systems, and products with their own distribution."
   },
@@ -106,7 +106,7 @@
     "title": "Selected Outcomes",
     "mau": "4.2k+ MAU across active products",
     "portfolio": "Portfolio: software products, directories & tools",
-    "experience": "Solo since 2024 · Valtech 2016–2022"
+    "experience": "Tech founder since 2024 · Valtech 2016–2022"
   },
   "contact": {
     "sendEmail": "Send email",


### PR DESCRIPTION
### Motivation
- Replace the previous "solo"/"independent" phrasing with the suggested professional wording to present the founder role as "Tech Founder" in English and "Digital-Unternehmer" in German.

### Description
- Updated `public/locales/en/common.json` to use "Tech Founder" across meta title, hero title, proof chip, about line, and outcomes experience.
- Updated `public/locales/de/common.json` to use "Digital-Unternehmer" across meta title, hero title, proof chip, about line, and outcomes experience.
- Two locale files were modified in total with equivalent copy changes for consistency across both languages.

### Testing
- Started the development server with `npm run dev` and the Next.js app compiled successfully, with font download fallback warnings and a non-critical non-boolean attribute warning reported.
- Captured a smoke-test screenshot using Playwright which produced the artifact `artifacts/tech-founder-hero.png` successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a30ae21b4832ca37c8ba9fe415c2c)