### PR TITLE
Render full project list in initial HTML (crawler-friendly, progressive enhancement)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A portfolio with basic information about skills and experience.
 
 - [About](#about)
 - [Getting Started](#getting-started)
+- [Verifying crawler-visible HTML](#verifying-crawler-visible-html)
 - [License](##license)
 
 ## About
@@ -26,6 +27,27 @@ git clone https://github.com/samiralibabic/portfolio.git
 cd portfolio
 npm install
 ```
+
+## Verifying crawler-visible HTML
+
+The `/de` homepage renders the full product list server-side (including the items hidden behind the “Show more products” interaction), so bots can see the same content as hydrated browsers.
+
+To verify locally:
+
+1. Build and start the app:
+
+```bash
+npm run build
+npm run start
+```
+
+2. Confirm the HTML payload contains the full product list:
+
+```bash
+curl -s http://localhost:3000/de | rg -i "products|show more|samiralibabic"
+```
+
+3. Optionally, run Lighthouse/SEO and confirm that the product cards and links are discoverable in the initial HTML response.
 
 ## Licence
 

--- a/src/components/Projects/Projects.js
+++ b/src/components/Projects/Projects.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import Masonry from 'react-masonry-css';
 import { useTranslation } from 'next-i18next';
 import Image from 'next/image';
@@ -47,21 +47,13 @@ const SOLD_PROJECT_IDS = [11]; // affiliatecompanies.net
 const FEATURED_PROJECT_IDS = [12, 13, 8, 2]; // PODB, tierarzt-liste, print2social, lustigedruckshirts.de - ClipClean moved to utilities
 
 const Projects = () => {
-  const { t, i18n } = useTranslation(['common', 'projects']);
-  const [discontinuedProjects, setDiscontinuedProjects] = useState(DISCONTINUED_PROJECT_IDS);
-  const [soldProjects, setSoldProjects] = useState(SOLD_PROJECT_IDS);
+  const { t } = useTranslation(['common', 'projects']);
   const [showMoreProjects, setShowMoreProjects] = useState(false);
-  
-  useEffect(() => {
-    // Force re-render when language changes
-    setDiscontinuedProjects([...DISCONTINUED_PROJECT_IDS]);
-    setSoldProjects([...SOLD_PROJECT_IDS]);
-  }, [i18n.language]);
 
   const orderedProjects = projects.slice().reverse();
 
   const isInactiveProjectId = (id) =>
-    discontinuedProjects.includes(id) || soldProjects.includes(id);
+    DISCONTINUED_PROJECT_IDS.includes(id) || SOLD_PROJECT_IDS.includes(id);
 
   const featuredProjects = orderedProjects.filter(({ id }) =>
     FEATURED_PROJECT_IDS.includes(id)
@@ -77,8 +69,8 @@ const Projects = () => {
 
   const renderProjectCard = ({ id, image, title, description, tags, visit }) => {
     // Check project status
-    const isDiscontinued = discontinuedProjects.includes(id);
-    const isSold = soldProjects.includes(id);
+    const isDiscontinued = DISCONTINUED_PROJECT_IDS.includes(id);
+    const isSold = SOLD_PROJECT_IDS.includes(id);
 
     // Get translated description with correct path
     const translatedDescription = t(`projects:projects.${id}.description`, { defaultValue: description });
@@ -217,8 +209,8 @@ const Projects = () => {
         </ProjectsControlsRow>
       )}
 
-      {showMoreProjects && (
-        <ProjectGroupsWrapper>
+      {(utilitiesProjects.length > 0 || inactiveProjects.length > 0) && (
+        <ProjectGroupsWrapper data-expanded={showMoreProjects}>
           {utilitiesProjects.length > 0 && (
             <ProjectGroupDetails open>
               <ProjectGroupSummary>

--- a/src/components/Projects/ProjectsStyles.js
+++ b/src/components/Projects/ProjectsStyles.js
@@ -169,12 +169,20 @@ export const ProjectsControlsRow = styled.div`
   display: flex;
   justify-content: center;
   margin: 24px 0 0;
+
+  html.no-js & {
+    display: none;
+  }
 `;
 
 export const ProjectGroupsWrapper = styled.div`
   width: 100%;
   max-width: 1200px;
   margin: 28px auto 0;
+
+  html.js &[data-expanded='false'] {
+    display: none;
+  }
 `;
 
 export const ProjectGroupDetails = styled.details`

--- a/src/pages/_document.js
+++ b/src/pages/_document.js
@@ -29,7 +29,7 @@ export default class MyDocument extends Document {
   }
   render() {
     return (
-      <Html lang='en-GB'>
+      <Html lang='en-GB' className="no-js">
         <Head>
           <meta charSet="utf-8" />
           <meta name="keywords" content="software engineer, digital entrepreneur, portfolio, web development" />
@@ -63,6 +63,12 @@ export default class MyDocument extends Document {
               }
             `}
           </style>
+          <script
+            dangerouslySetInnerHTML={{
+              __html:
+                "document.documentElement.classList.remove('no-js');document.documentElement.classList.add('js');",
+            }}
+          />
         </Head>
         <body>
           <Main />


### PR DESCRIPTION
### Motivation

- Ensure automated agents/crawlers see the same product listing content as human users on the `/de` homepage without changing visible UI, layout, or copy. 
- Preserve the existing client-side “Show more products” interaction while making the extra items present in the initial HTML so they are indexable. 

### Description

- Render utility and inactive project groups in the initial HTML by always including the groups in `Projects` and controlling their visible state with a `data-expanded` attribute instead of conditionally rendering them after hydration (`src/components/Projects/Projects.js`).
- Remove client-only state for discontinued/sold ID lists and reference the constants directly so content is deterministic at render time (`DISCONTINUED_PROJECT_IDS`, `SOLD_PROJECT_IDS`).
- Add progressive-enhancement CSS hooks to hide the show-more controls when JavaScript is disabled and to collapse extra groups only when JS is active and `data-expanded='false'` (`src/components/Projects/ProjectsStyles.js`).
- Add a `no-js` class to the root `<Html>` and an inline script that swaps `no-js` → `js` on the client to allow CSS to distinguish JS vs no-JS rendering (`src/pages/_document.js`).
- Document curl-based verification and a Lighthouse/SEO suggestion in `README.md` so developers can confirm the initial HTML contains the same product names/links as the hydrated page.

### Testing

- No automated tests were executed as part of this change; the patch is focused on SSR/markup and progressive-enhancement behavior.
- Manual verification steps were added to `README.md` and recommend running the local build and `curl` (or Lighthouse/SEO) checks to confirm that the initial HTML contains the full product list and links. 
- Changes are scoped to rendering and CSS behavior and do not alter visible copy, markup structure of product cards, or external product links.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a8ae54c94832cabc09334deb88aff)