### PR TITLE
Render full product list in SSR and add SSR verification script

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ npm install
 
 ## Verifying crawler-visible HTML
 
-The `/de` homepage renders the full product list server-side (including the items hidden behind the “Show more products” interaction), so bots can see the same content as hydrated browsers.
+The homepage renders the full product list server-side (including the items hidden behind the “Show more products” interaction), so bots can see the same content as hydrated browsers.
 
 To verify locally:
 
@@ -41,13 +41,19 @@ npm run build
 npm run start
 ```
 
-2. Confirm the HTML payload contains the full product list:
+2. Confirm the HTML payload contains the full product list (example uses a product name that appears in the “Show more products” section):
 
 ```bash
-curl -s http://localhost:3000/de | rg -i "products|show more|samiralibabic"
+curl -s http://localhost:3000/ | rg -i "ClipClean|Print2Social|Tierarzt-Liste"
 ```
 
-3. Optionally, run Lighthouse/SEO and confirm that the product cards and links are discoverable in the initial HTML response.
+3. Run the dev-only SSR check script to assert every product title + link exists in the HTML:
+
+```bash
+npm run check:ssr-products
+```
+
+4. In a browser, use “View Source” and search for any product title or link to confirm the full list is present in the raw HTML.
 
 ## Licence
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "start": "next start"
+    "start": "next start",
+    "check:ssr-products": "node scripts/check-products-ssr.mjs"
   },
   "dependencies": {
     "@vercel/analytics": "^1.3.1",

--- a/scripts/check-products-ssr.mjs
+++ b/scripts/check-products-ssr.mjs
@@ -1,0 +1,36 @@
+import { projects } from '../src/constants/constants.js';
+
+const url = process.env.SSR_CHECK_URL || 'http://localhost:3000/';
+
+const response = await fetch(url);
+if (!response.ok) {
+  throw new Error(`Failed to fetch ${url} (${response.status})`);
+}
+
+const html = await response.text();
+
+const missingTitles = [];
+const missingLinks = [];
+
+for (const project of projects) {
+  if (!html.includes(project.title)) {
+    missingTitles.push(project.title);
+  }
+
+  if (!html.includes(project.visit)) {
+    missingLinks.push(project.visit);
+  }
+}
+
+if (missingTitles.length || missingLinks.length) {
+  const message = [
+    missingTitles.length ? `Missing titles: ${missingTitles.join(', ')}` : null,
+    missingLinks.length ? `Missing links: ${missingLinks.join(', ')}` : null,
+  ]
+    .filter(Boolean)
+    .join(' | ');
+
+  throw new Error(`SSR product check failed: ${message}`);
+}
+
+console.log(`SSR product check passed for ${projects.length} projects at ${url}`);

--- a/src/components/Projects/Projects.js
+++ b/src/components/Projects/Projects.js
@@ -12,6 +12,7 @@ import {
   TitleContent,
   ImgOverlay,
   ProjectStatusBanner,
+  ProjectCardLink,
   ProjectsControlsRow,
   ProjectGroupsWrapper,
   ProjectGroupDetails,
@@ -71,6 +72,7 @@ const Projects = () => {
     // Check project status
     const isDiscontinued = DISCONTINUED_PROJECT_IDS.includes(id);
     const isSold = SOLD_PROJECT_IDS.includes(id);
+    const isInactive = isDiscontinued || isSold;
 
     // Get translated description with correct path
     const translatedDescription = t(`projects:projects.${id}.description`, { defaultValue: description });
@@ -80,6 +82,10 @@ const Projects = () => {
       .replace('[DISCONTINUED]', '')
       .replace('[EINGESTELLT]', '')
       .trim();
+
+    const linkProps = isInactive
+      ? { 'data-disabled': 'true', 'aria-disabled': 'true', tabIndex: -1 }
+      : { target: '_blank', rel: 'noopener noreferrer' };
 
     return (
       <BlogCard key={id}>
@@ -95,94 +101,46 @@ const Projects = () => {
           </ProjectStatusBanner>
         )}
 
-        {/* Wrap the entire card in a link if not discontinued or sold */}
-        {(isDiscontinued || isSold) ? (
-          <>
-            {/* Image with grayscale for discontinued/sold projects */}
-            {image && (
-              <ImgOverlay>
-                <div style={{ position: 'relative', width: '100%', height: '200px' }}>
-                  <Image 
-                    src={image} 
-                    alt={title} 
-                    fill
-                    sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
-                    style={{ 
-                      objectFit: 'cover',
-                      filter: 'grayscale(100%)',
-                      borderRadius: '12px 12px 0 0'
-                    }}
-                    priority={id === 12}
-                    loading={id === 12 ? "eager" : "lazy"}
-                    quality={id === 12 ? 90 : 75}
-                    placeholder="blur"
-                    blurDataURL="data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/4gHYSUNDX1BST0ZJTEUAAQEAAAHIAAAAAAQwAABtbnRyUkdCIFhZWiAH4AABAAEAAAAAAABhY3NwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAA9tYAAQAAAADTLQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAlkZXNjAAAA8AAAACRyWFlaAAABFAAAABRnWFlaAAABKAAAABRiWFlaAAABPAAAABR3dHB0AAABUAAAABRyVFJDAAABZAAAAChnVFJDAAABZAAAAChiVFJDAAABZAAAAChjcHJ0AAABjAAAADxtbHVjAAAAAAAAAAEAAAAMZW5VUwAAAAgAAAAcAHMAUgBHAEJYWVogAAAAAAAAb6IAADj1AAADkFhZWiAAAAAAAABimQAAt4UAABjaWFlaIAAAAAAAACSgAAAPhAAAts9YWVogAAAAAAAA9tYAAQAAAADTLXBhcmEAAAAAAAQAAAACZmYAAPKnAAANWQAAE9AAAApbAAAAAAAAAABtbHVjAAAAAAAAAAEAAAAMZW5VUwAAACAAAAAcAEcAbwBvAGcAbABlACAASQBuAGMALgAgADIAMAAxADb/2wBDABQODxIPDRQSEBIXFRQdHx4eHRoaHSQtJSEkLzYvLy82NDQ0NDY0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDT/2wBDAR0XFyAeIR4hISE0LSotNDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDT/wAARCAAIAAoDASIAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAb/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/8QAFQEBAQAAAAAAAAAAAAAAAAAAAAb/xAAUEQEAAAAAAAAAAAAAAAAAAAAA/9oADAMBAAIRAxEAPwCdABmX/9k="
-                  />
-                </div>
-              </ImgOverlay>
-            )}
+        <ProjectCardLink href={visit} {...linkProps}>
+          {/* Image */}
+          {image && (
+            <ImgOverlay>
+              <div style={{ position: 'relative', width: '100%', height: '200px' }}>
+                <Image 
+                  src={image} 
+                  alt={title} 
+                  fill
+                  sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
+                  style={{ 
+                    objectFit: 'cover',
+                    filter: isInactive ? 'grayscale(100%)' : 'none',
+                    borderRadius: '12px 12px 0 0'
+                  }}
+                  priority={id === 12}
+                  loading={id === 12 ? "eager" : "lazy"}
+                  quality={id === 12 ? 90 : 75}
+                  placeholder="blur"
+                  blurDataURL="data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/4gHYSUNDX1BST0ZJTEUAAQEAAAHIAAAAAAQwAABtbnRyUkdCIFhZWiAH4AABAAEAAAAAAABhY3NwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAA9tYAAQAAAADTLQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAlkZXNjAAAA8AAAACRyWFlaAAABFAAAABRnWFlaAAABKAAAABRiWFlaAAABPAAAABR3dHB0AAABUAAAABRyVFJDAAABZAAAAChnVFJDAAABZAAAAChiVFJDAAABZAAAAChjcHJ0AAABjAAAADxtbHVjAAAAAAAAAAEAAAAMZW5VUwAAAAgAAAAcAHMAUgBHAEJYWVogAAAAAAAAb6IAADj1AAADkFhZWiAAAAAAAABimQAAt4UAABjaWFlaIAAAAAAAACSgAAAPhAAAts9YWVogAAAAAAAA9tYAAQAAAADTLXBhcmEAAAAAAAQAAAACZmYAAPKnAAANWQAAE9AAAApbAAAAAAAAAABtbHVjAAAAAAAAAAEAAAAMZW5VUwAAACAAAAAcAEcAbwBvAGcAbABlACAASQBuAGMALgAgADIAMAAxADb/2wBDABQODxIPDRQSEBIXFRQdHx4eHRoaHSQtJSEkLzYvLy82NDQ0NDY0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDT/2wBDAR0XFyAeIR4hISE0LSotNDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDT/wAARCAAIAAoDASIAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAb/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/8QAFQEBAQAAAAAAAAAAAAAAAAAAAAb/xAAUEQEAAAAAAAAAAAAAAAAAAAAA/9oADAMBAAIRAxEAPwCdABmX/9k="
+                />
+              </div>
+            </ImgOverlay>
+          )}
 
-            <TitleContent>
-              <HeaderThree title={title}>
-                <span>{title}</span>
-              </HeaderThree>
-              <Hr />
-            </TitleContent>
-            <CardInfo>{cleanDescription}</CardInfo>
-            <div>
-              <TagList>
-                {tags.map((tag, i) => (
-                  <Tag key={i}>{tag}</Tag>
-                ))}
-              </TagList>
-            </div>
-          </>
-        ) : (
-          <a href={visit} target="_blank" rel="noopener noreferrer" style={{ 
-            display: 'block', 
-            textDecoration: 'none',
-            color: 'inherit',
-            height: '100%'
-          }}>
-            {/* Image for active projects */}
-            {image && (
-              <ImgOverlay>
-                <div style={{ position: 'relative', width: '100%', height: '200px' }}>
-                  <Image 
-                    src={image} 
-                    alt={title} 
-                    fill
-                    sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
-                    style={{ 
-                      objectFit: 'cover',
-                      borderRadius: '12px 12px 0 0'
-                    }}
-                    priority={id === 12}
-                    loading={id === 12 ? "eager" : "lazy"}
-                    quality={id === 12 ? 90 : 75}
-                    placeholder="blur"
-                    blurDataURL="data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/4gHYSUNDX1BST0ZJTEUAAQEAAAHIAAAAAAQwAABtbnRyUkdCIFhZWiAH4AABAAEAAAAAAABhY3NwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAA9tYAAQAAAADTLQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAlkZXNjAAAA8AAAACRyWFlaAAABFAAAABRnWFlaAAABKAAAABRiWFlaAAABPAAAABR3dHB0AAABUAAAABRyVFJDAAABZAAAAChnVFJDAAABZAAAAChiVFJDAAABZAAAAChjcHJ0AAABjAAAADxtbHVjAAAAAAAAAAEAAAAMZW5VUwAAAAgAAAAcAHMAUgBHAEJYWVogAAAAAAAAb6IAADj1AAADkFhZWiAAAAAAAABimQAAt4UAABjaWFlaIAAAAAAAACSgAAAPhAAAts9YWVogAAAAAAAA9tYAAQAAAADTLXBhcmEAAAAAAAQAAAACZmYAAPKnAAANWQAAE9AAAApbAAAAAAAAAABtbHVjAAAAAAAAAAEAAAAMZW5VUwAAACAAAAAcAEcAbwBvAGcAbABlACAASQBuAGMALgAgADIAMAAxADb/2wBDABQODxIPDRQSEBIXFRQdHx4eHRoaHSQtJSEkLzYvLy82NDQ0NDY0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDT/2wBDAR0XFyAeIR4hISE0LSotNDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDT/wAARCAAIAAoDASIAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAb/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/8QAFQEBAQAAAAAAAAAAAAAAAAAAAAb/xAAUEQEAAAAAAAAAAAAAAAAAAAAA/9oADAMBAAIRAxEAPwCdABmX/9k="
-                  />
-                </div>
-              </ImgOverlay>
-            )}
-
-            <TitleContent>
-              <HeaderThree title={title}>
-                {title}
-              </HeaderThree>
-              <Hr />
-            </TitleContent>
-            <CardInfo>{cleanDescription}</CardInfo>
-            <div>
-              <TagList>
-                {tags.map((tag, i) => (
-                  <Tag key={i}>{tag}</Tag>
-                ))}
-              </TagList>
-            </div>
-          </a>
-        )}
+          <TitleContent>
+            <HeaderThree title={title}>
+              {title}
+            </HeaderThree>
+            <Hr />
+          </TitleContent>
+          <CardInfo>{cleanDescription}</CardInfo>
+          <div>
+            <TagList>
+              {tags.map((tag, i) => (
+                <Tag key={i}>{tag}</Tag>
+              ))}
+            </TagList>
+          </div>
+        </ProjectCardLink>
       </BlogCard>
     );
   };
@@ -203,14 +161,21 @@ const Projects = () => {
 
       {(utilitiesProjects.length > 0 || inactiveProjects.length > 0) && (
         <ProjectsControlsRow>
-          <Button onClick={() => setShowMoreProjects((prev) => !prev)}>
+          <Button
+            onClick={() => setShowMoreProjects((prev) => !prev)}
+            aria-expanded={showMoreProjects}
+            aria-controls="project-groups"
+          >
             {showMoreProjects ? t('common:projects.showLess') : t('common:projects.showMore')}
           </Button>
         </ProjectsControlsRow>
       )}
 
       {(utilitiesProjects.length > 0 || inactiveProjects.length > 0) && (
-        <ProjectGroupsWrapper data-expanded={showMoreProjects}>
+        <ProjectGroupsWrapper
+          id="project-groups"
+          data-expanded={showMoreProjects ? 'true' : 'false'}
+        >
           {utilitiesProjects.length > 0 && (
             <ProjectGroupDetails open>
               <ProjectGroupSummary>

--- a/src/components/Projects/ProjectsStyles.js
+++ b/src/components/Projects/ProjectsStyles.js
@@ -164,6 +164,18 @@ export const ProjectStatusBanner = styled.div`
   }};
 `
 
+export const ProjectCardLink = styled.a`
+  display: block;
+  text-decoration: none;
+  color: inherit;
+  height: 100%;
+
+  &[data-disabled='true'] {
+    cursor: default;
+    pointer-events: none;
+  }
+`;
+
 export const ProjectsControlsRow = styled.div`
   width: 100%;
   display: flex;


### PR DESCRIPTION
### Motivation

- Ensure the full product list (including items currently revealed by the “Show more products” interaction) is present in the initial HTML so crawlers and view-source users see the same content as hydrated browsers. 
- Keep the existing user-visible behavior and styling unchanged while using progressive enhancement so the collapse/reveal still works for JS users and degrades gracefully when JS is disabled.

### Description

- Server-render every project card as a real `<a href="...">` by introducing a `ProjectCardLink` styled component and using it for all project cards so titles and links exist in the initial HTML. 
- Preserve inactive/discontinued styling and disable pointer interactions for those cards using `data-disabled` and CSS (cards still render but are non-interactive). 
- Keep the progressive reveal behavior by toggling `data-expanded` on the `ProjectGroupsWrapper` and relying on existing `html.no-js`/`html.js` rules so the initial collapsed UI and the “Show more” control remain unchanged for users. 
- Add a dev-only SSR verification script `scripts/check-products-ssr.mjs` and an npm script `npm run check:ssr-products` that fetches the homepage HTML and asserts every product title and link from `src/constants/constants.js` is present, and update `README.md` with curl/View Source verification steps.

### Testing

- No automated test suite was executed as part of this change; a developer can run the new check with `npm run build && npm run start` followed by `npm run check:ssr-products`, and the script will exit successfully if every product title and link is present in the homepage HTML. 
- The change is implemented to be progressive and does not alter the visible collapse/reveal UX for JS-enabled users, and the `html.no-js` / `html.js` mechanism ensures links are still exposed when JavaScript is disabled.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a8e6c0340832cad16d924851e142d)