### PR TITLE
Prevent 3+1 masonry by removing 3-column breakpoint; add project-group helpers and tighten copy

### DIFF
--- a/public/locales/de/common.json
+++ b/public/locales/de/common.json
@@ -1,17 +1,16 @@
 {
   "meta": {
     "title": "Samir Alibabic - Software-Ingenieur & Digital-Unternehmer",
-    "description": "Ich baue und betreibe Software-Produkte end-to-end – von Code & Daten bis Distribution. Fokus: organisches Wachstum (SEO/Content/Community) und klare, messbare Systeme."
+    "description": "Ich baue und betreibe Software-Produkte. Fokus: einfache Systeme, klare Ergebnisse."
   },
   "hero": {
     "title": "Software-Ingenieur & Digital-Unternehmer",
-    "intro": "Ich baue und betreibe Software-Produkte end-to-end – von Code & Daten bis Distribution.",
-    "introSecondLine": "Fokus: organisches Wachstum (SEO/Content/Community) und klare, messbare Systeme.",
+    "intro": "Ich baue und betreibe Software-Produkte.",
+    "introSecondLine": "Von Code und Daten bis zu Wachstum (SEO, Content, Community).",
     "contact": "Kontakt",
     "exploreProducts": "Produkte ansehen",
     "readBlog": "Blog lesen",
     "proofChips": {
-      "mau": "4.2k+ MAU über aktive Produkte",
       "solo": "Digital-Unternehmer seit 2024",
       "valtech": "Valtech (2016–2022)",
       "germany": "Deutschland",
@@ -37,13 +36,15 @@
     "sold": "AKQUIRIERT",
     "showMore": "Mehr Produkte anzeigen",
     "showLess": "Weniger Produkte anzeigen",
-    "utilities": "Tools",
-    "inactive": "Inaktiv"
+    "utilities": "Labs",
+    "utilitiesHelper": "Experimente und kleine Tools. Nützlich, aber nicht mein Hauptfokus.",
+    "inactive": "Archiv",
+    "inactiveHelper": "Ältere Projekte: verkauft oder eingestellt."
   },
   "buildDetails": {
     "title": "Technische Details",
     "close": "Technische Details schließen",
-    "intro": "Ich baue und betreibe digitale Produkte durchgängig – von der Idee bis zur Produktion. Ich bin nicht an einen festen Technologie-Stack gebunden; Werkzeuge wähle ich danach aus, was die Aufgabe verlangt.",
+    "intro": "Ich baue Produkte von der Idee bis zum Betrieb. Die Tools wähle ich nach der Aufgabe.",
     "list": {
       "plan": "Was ich tue: planen, bauen, betreiben, messen, verbessern",
       "workStyle": "Wie ich arbeite: pragmatisch, schnell, fokussiert auf Ergebnisse",
@@ -94,9 +95,9 @@
   "about": {
     "title": "Über Mich",
     "subtitle": "Mein Hintergrund und meine Reise",
-    "bioLine1": "Ich entwickle seit 2009 Software und baue seit 2024 Produkte als Digital-Unternehmer.",
-    "bioLine2": "Davor: Software Engineer bei Valtech (2016–2022).",
-    "bioLine3": "Heute: organisches Wachstum, klare Systeme und Produkte mit eigener Distribution."
+    "bioLine1": "Ich baue seit 2009 Software.",
+    "bioLine2": "Seit 2024 arbeite ich als Solo-Founder an eigenen Produkten.",
+    "bioLine3": "Davor: Software Engineer bei Valtech (2016–2022)."
   },
   "testimonials": {
     "title": "Referenzen",
@@ -104,7 +105,6 @@
   },
   "outcomes": {
     "title": "Ausgewählte Ergebnisse",
-    "mau": "4.2k+ MAU über aktive Produkte",
     "portfolio": "Portfolio: Software-Produkte, Verzeichnisse & Tools",
     "experience": "Digital-Unternehmer seit 2024 · Valtech 2016–2022"
   },
@@ -117,8 +117,8 @@
   },
   "now": {
     "title": "Aktuell",
-    "focus": "Aktuell: Fokus auf PODB & Tierarzt-Liste (Wachstum + Monetarisierung).",
-    "openTo": "Offen für: Sponsorships, Integrationen, Partnerschaften."
+    "focus": "Aktuell: Fokus auf PrintOnDemandBusiness und Tierarzt-Liste.",
+    "openTo": "Offen für: Sponsoring, Integrationen, Partnerschaften."
   },
   "footer": {
     "privacy": "Datenschutzerklärung",

--- a/public/locales/de/projects.json
+++ b/public/locales/de/projects.json
@@ -2,52 +2,52 @@
   "projects": {
     "title": "Produkte",
     "0": {
-      "description": "Eine Plattform zum Organisieren, Verfolgen und Analysieren der Leistung geteilter Links."
+      "description": "Links speichern und Klicks auswerten."
     },
     "1": {
-      "description": "[EINGESTELLT] Verwandeln Sie Ihren Hashnode-Blog in eine Notion-Datenbank und verwalten Sie ihn zusammen mit allem anderen."
+      "description": "Hashnode-Blog in Notion speichern und verwalten."
     },
     "2": {
-      "description": "Ein Print-On-Demand-Shop für humorvolle T-Shirts und Taschen auf dem deutschen Markt."
+      "description": "Humor-Merch für den deutschen Markt."
     },
     "3": {
-      "description": "Ein Print-On-Demand-Shop für reisebezogene Produkte auf dem deutschen Markt."
+      "description": "Shop (eingestellt)."
     },
     "4": {
-      "description": "[EINGESTELLT] Ein Print-On-Demand-Shop für Hunde- und Katzenliebhaber auf dem deutschen Markt."
+      "description": "Shop (eingestellt)."
     },
     "5": {
-      "description": "Ein Print-On-Demand-Shop für Retro-Stil Heim und Dekorationen auf dem deutschen Markt."
+      "description": "Shop (eingestellt)."
     },
     "6": {
-      "description": "[EINGESTELLT] Ein Print-On-Demand-Shop für Babyprodukte auf dem deutschen Markt."
+      "description": "Shop (eingestellt)."
     },
     "7": {
-      "description": "Eine Notion-Vorlage für Noah Kagans Buch \"Million Dollar Weekend\"."
+      "description": "Notion-Vorlage für „Million Dollar Weekend“."
     },
     "8": {
-      "description": "Ein KI-gesteuerter Social-Media-Manager für Print-On-Demand-Unternehmen."
+      "description": "Social Media für Print-on-Demand einfacher machen."
     },
     "9": {
-      "description": "Eine Nischen-Website mit lustigen Sprüchen und Witzen, die Traffic zu anderen Produkten lenkt."
+      "description": "Sprüche und Witze. Ein Traffic-Experiment."
     },
     "10": {
-      "description": "Ein Web-Crawler zum Sammeln externer Links von beliebigen Seiten oder ganzen Domains."
+      "description": "Crawlt Seiten und sammelt Links."
     },
     "11": {
-      "description": "Entdecken Sie die besten Partnerprogramme mit ausgezeichnetem Verdienstpotenzial."
+      "description": "Verzeichnis für Affiliate-Programme."
     },
     "12": {
-      "description": "Ein Verzeichnis und Content-Hub für Print-on-Demand: Anbieter finden, vergleichen und Entscheidungen schneller treffen."
+      "description": "Print-on-Demand-Anbieter finden und vergleichen."
     },
     "13": {
-      "description": "Ein umfassendes Tierarztverzeichnis für Deutschland – mit Fokus auf Auffindbarkeit, Struktur und lokale Suche."
+      "description": "Tierärzte in Deutschland finden. Lokal und strukturiert."
     },
     "14": {
-      "description": "Ein KI-gestützter Audio-Bereinigungsservice, der Füllwörter und peinliche Pausen aus Podcasts und Aufnahmen entfernt."
+      "description": "Macht Audio sauberer: weniger Füllwörter, weniger Pausen."
     },
     "15": {
-      "description": "Ein Monitoring-Tool für Verfügbarkeits- und Performance-Prüfungen von Websites und Services."
+      "description": "Überwacht Websites: Uptime und Performance."
     }
   }
 }

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -1,17 +1,16 @@
 {
   "meta": {
     "title": "Samir Alibabic - Software Engineer & Tech Founder",
-    "description": "I build and operate software products end-to-end — from code & data to distribution. Focus: organic growth (SEO/content/community) and clear, measurable systems."
+    "description": "I build and run software products. Focus: simple systems, clear outcomes."
   },
   "hero": {
     "title": "Software Engineer & Tech Founder",
-    "intro": "I build and operate software products end-to-end — from code & data to distribution.",
-    "introSecondLine": "Focus: organic growth (SEO/content/community) and clear, measurable systems.",
+    "intro": "I build and run software products.",
+    "introSecondLine": "From code and data to growth (SEO, content, community).",
     "contact": "Contact",
     "exploreProducts": "Explore products",
     "readBlog": "Read the blog",
     "proofChips": {
-      "mau": "4.2k+ MAU across active products",
       "solo": "Tech founder since 2024",
       "valtech": "Valtech (2016–2022)",
       "germany": "Germany",
@@ -37,13 +36,15 @@
     "sold": "ACQUIRED",
     "showMore": "Show more products",
     "showLess": "Show fewer products",
-    "utilities": "Utilities",
-    "inactive": "Inactive"
+    "utilities": "Labs",
+    "utilitiesHelper": "Experiments and small tools. Useful, but not my main focus.",
+    "inactive": "Archive",
+    "inactiveHelper": "Older projects: sold or discontinued."
   },
   "buildDetails": {
     "title": "Build details",
     "close": "Close build details",
-    "intro": "I build and run digital products end-to-end — from idea to production. I’m not tied to a specific tech stack; tools are chosen based on what the problem needs.",
+    "intro": "I build products from idea to operation. I choose tools based on the task.",
     "list": {
       "plan": "What I do: plan, build, operate, measure, improve",
       "workStyle": "How I work: pragmatic, fast, focused on outcomes",
@@ -94,9 +95,9 @@
   "about": {
     "title": "About Me",
     "subtitle": "My background and journey",
-    "bioLine1": "I've been building software since 2009 and have been operating products as a tech founder since 2024.",
-    "bioLine2": "Previously: Software Engineer at Valtech (2016–2022).",
-    "bioLine3": "Today: organic growth, clear systems, and products with their own distribution."
+    "bioLine1": "I’ve been building software since 2009.",
+    "bioLine2": "Since 2024, I’ve been working on my own products as a solo founder.",
+    "bioLine3": "Previously: Software Engineer at Valtech (2016–2022)."
   },
   "testimonials": {
     "title": "Testimonials",
@@ -104,7 +105,6 @@
   },
   "outcomes": {
     "title": "Selected Outcomes",
-    "mau": "4.2k+ MAU across active products",
     "portfolio": "Portfolio: software products, directories & tools",
     "experience": "Tech founder since 2024 · Valtech 2016–2022"
   },
@@ -117,7 +117,7 @@
   },
   "now": {
     "title": "Now",
-    "focus": "Now: focused on PODB & Tierarzt-Liste (growth + monetization).",
+    "focus": "Now: focused on PrintOnDemandBusiness and Tierarzt-Liste.",
     "openTo": "Open to: sponsorships, integrations, partnerships."
   },
   "footer": {

--- a/public/locales/en/projects.json
+++ b/public/locales/en/projects.json
@@ -2,52 +2,52 @@
   "projects": {
     "title": "Products",
     "0": {
-      "description": "A platform to organize, track, and analyze the performance of shared links."
+      "description": "Save links and track clicks."
     },
     "1": {
-      "description": "[DISCONTINUED] Turn your Hashnode blog into a Notion database and manage it with everything else."
+      "description": "Save a Hashnode blog in Notion."
     },
     "2": {
-      "description": "A Print-On-Demand shop for humorous T-shirts and bags in the German market."
+      "description": "Humor merch for the German market."
     },
     "3": {
-      "description": "A Print-On-Demand shop for travel-related products in the German market."
+      "description": "Store (discontinued)."
     },
     "4": {
-      "description": "[DISCONTINUED] A Print-On-Demand shop for dog and cat lovers in the German market."
+      "description": "Store (discontinued)."
     },
     "5": {
-      "description": "A Print-On-Demand shop for retro-style home and decorations in the German market."
+      "description": "Store (discontinued)."
     },
     "6": {
-      "description": "[DISCONTINUED] A Print-On-Demand shop for baby products in the German market."
+      "description": "Store (discontinued)."
     },
     "7": {
-      "description": "A Notion template for Noah Kagan's book \"Million Dollar Weekend.\""
+      "description": "Notion template for “Million Dollar Weekend”."
     },
     "8": {
-      "description": "An AI-powered social media manager for Print-On-Demand businesses."
+      "description": "Make social media easier for print-on-demand sellers."
     },
     "9": {
-      "description": "A niche German website with funny slogans and jokes that drives traffic to other ventures."
+      "description": "Funny quotes. A traffic experiment."
     },
     "10": {
-      "description": "A web crawler to gather external links from any page or entire domain."
+      "description": "Crawls pages and collects links."
     },
     "11": {
-      "description": "Discover the top affiliate programs with excellent earning potential."
+      "description": "Affiliate program directory."
     },
     "12": {
-      "description": "A directory and content hub for print-on-demand: find vendors, compare options, and make decisions faster."
+      "description": "Find and compare print-on-demand suppliers."
     },
     "13": {
-      "description": "A comprehensive veterinary directory for Germany — focused on discoverability, structure, and local search."
+      "description": "Find vets in Germany. Local and structured."
     },
     "14": {
-      "description": "An AI-powered audio cleaning service that removes filler words and awkward pauses from podcasts and recordings."
+      "description": "Cleaner audio: fewer filler words, fewer awkward pauses."
     },
     "15": {
-      "description": "A monitoring tool for uptime and performance checks on websites and services."
+      "description": "Website monitoring: uptime and performance."
     }
   }
-} 
+}

--- a/src/components/Hero/Hero.js
+++ b/src/components/Hero/Hero.js
@@ -19,7 +19,6 @@ const Hero = (props) => {
         <span style={{ opacity: 0.8 }}>{t('hero.introSecondLine')}</span>
       </SectionText>
       <ProofChipsContainer>
-        <ProofChip>{t('hero.proofChips.mau')}</ProofChip>
         <ProofChip>{t('hero.proofChips.solo')}</ProofChip>
         <ProofChip>{t('hero.proofChips.valtech')}</ProofChip>
         <ProofChip>{t('hero.proofChips.germany')}</ProofChip>

--- a/src/components/Projects/Projects.js
+++ b/src/components/Projects/Projects.js
@@ -17,6 +17,7 @@ import {
   ProjectGroupsWrapper,
   ProjectGroupDetails,
   ProjectGroupSummary,
+  ProjectGroupHelper,
   ProjectGroupContent,
 } from './ProjectsStyles';
 import { Section, SectionDivider, SectionTitle } from '../../styles/GlobalComponents';
@@ -25,8 +26,8 @@ import { projects } from '../../constants/constants';
 
 // Masonry breakpoints
 const breakpointColumnsObj = {
-  default: 3,
-  1100: 2,
+  default: 4,
+  1200: 2,
   700: 1
 };
 
@@ -182,6 +183,7 @@ const Projects = () => {
                 {t('common:projects.utilities')} ({utilitiesProjects.length})
               </ProjectGroupSummary>
               <ProjectGroupContent>
+                <ProjectGroupHelper>{t('common:projects.utilitiesHelper')}</ProjectGroupHelper>
                 <div style={containerStyle}>
                   <Masonry
                     breakpointCols={breakpointColumnsObj}
@@ -201,6 +203,7 @@ const Projects = () => {
                 {t('common:projects.inactive')} ({inactiveProjects.length})
               </ProjectGroupSummary>
               <ProjectGroupContent>
+                <ProjectGroupHelper>{t('common:projects.inactiveHelper')}</ProjectGroupHelper>
                 <div style={containerStyle}>
                   <Masonry
                     breakpointCols={breakpointColumnsObj}

--- a/src/components/Projects/ProjectsStyles.js
+++ b/src/components/Projects/ProjectsStyles.js
@@ -220,6 +220,12 @@ export const ProjectGroupSummary = styled.summary`
   }
 `;
 
+export const ProjectGroupHelper = styled.p`
+  margin: 4px 2px 0;
+  color: rgba(255, 255, 255, 0.65);
+  font-size: 0.95rem;
+`;
+
 export const ProjectGroupContent = styled.div`
   margin-top: 16px;
 `;

--- a/src/constants/constants.js
+++ b/src/constants/constants.js
@@ -1,7 +1,7 @@
 export const projects = [
   {
     title: 'LinkTracker',
-    description: 'A platform to organize, track, and analyze the performance of shared links.',
+    description: 'Save links and track clicks.',
     image: '/images/linktracker.webp',
     tags: ['SaaS', 'Link Management'],
     visit: 'https://linktracker.info',
@@ -9,7 +9,7 @@ export const projects = [
   },
   {
     title: 'hashion',
-    description: 'Turn your Hashnode blog into a Notion database and manage it with everything else.',
+    description: 'Save a Hashnode blog in Notion.',
     image: '/images/hashion.webp',
     tags: ['Blogging', 'Notion', 'Hashnode'],
     visit: 'https://hashion.link',
@@ -17,7 +17,7 @@ export const projects = [
   },
   {
     title: 'LustigeDruckShirts',
-    description: 'A Print-On-Demand shop for humorous T-shirts and bags in the German market.',
+    description: 'Humor merch for the German market.',
     image: '/images/lustigedruckshirts.webp',
     tags: ['Print-On-Demand', 'E-commerce'],
     visit: 'https://lustigedruckshirts.de',
@@ -25,7 +25,7 @@ export const projects = [
   },
   {
     title: 'Reise Prints',
-    description: 'A Print-On-Demand shop for travel-related products in the German market.',
+    description: 'Store (discontinued).',
     image: '/images/reiseprints.webp',
     tags: ['Print-On-Demand', 'Travel'],
     visit: 'https://reiseprints.de',
@@ -33,7 +33,7 @@ export const projects = [
   },
   {
     title: 'Hunde & Katzen Druck',
-    description: 'A Print-On-Demand shop for dog and cat lovers in the German market.',
+    description: 'Store (discontinued).',
     image: '/images/hundekatzendruck.webp',
     tags: ['Print-On-Demand', 'E-commerce'],
     visit: 'https://hundekatzendruck.de',
@@ -41,7 +41,7 @@ export const projects = [
   },
   {
     title: 'Retro Heim & Leben',
-    description: 'A Print-On-Demand shop for retro-style home and decorations in the German market.',
+    description: 'Store (discontinued).',
     image: '/images/retroheimundleben.webp',
     tags: ['Print-On-Demand', 'Home Decor'],
     visit: 'https://retroheimundleben.de',
@@ -49,7 +49,7 @@ export const projects = [
   },
   {
     title: 'Personalisierte Babykleidung',
-    description: 'A Print-On-Demand shop for baby products in the German market.',
+    description: 'Store (discontinued).',
     image: '/images/personalisiertebabykleidung.webp',
     tags: ['Print-On-Demand', 'Baby Products'],
     visit: 'https://personalisiertebabykleidung.de',
@@ -57,7 +57,7 @@ export const projects = [
   },
   {
     title: 'Notion Template (MDW)',
-    description: "A Notion template for Noah Kagan's book \"Million Dollar Weekend.\"",
+    description: 'Notion template for “Million Dollar Weekend”.',
     image: '/images/notion-template.webp',
     tags: ['Notion', 'Templates'],
     visit: 'https://www.notion.so/templates/million-dollar-weekend-workbook',
@@ -65,7 +65,7 @@ export const projects = [
   },
   {
     title: 'Print2Social',
-    description: 'An AI-powered social media manager for Print-On-Demand businesses.',
+    description: 'Make social media easier for print-on-demand sellers.',
     image: '/images/print2social.webp',
     tags: ['SaaS', 'Automation', 'Print-On-Demand'],
     visit: 'https://print2social.com',
@@ -73,7 +73,7 @@ export const projects = [
   },
   {
     title: 'Lustige Sprüche',
-    description: 'A niche German website with funny slogans and jokes that drives traffic to other ventures.',
+    description: 'Funny quotes. A traffic experiment.',
     image: '/images/lustigesprueche.webp',
     tags: ['SEO', 'Blogging', 'Humor'],
     visit: 'https://lustigesprueche.online',
@@ -81,7 +81,7 @@ export const projects = [
   },
   {
     title: 'WebCrawler',
-    description: 'A web crawler to gather external links from any page or entire domain.',
+    description: 'Crawls pages and collects links.',
     image: '/images/webcrawler.webp',
     tags: ['Web Crawling', 'Link Building'],
     visit: 'https://crawler.samiralibabic.com',
@@ -89,7 +89,7 @@ export const projects = [
   },
   {
     title: 'Monitor',
-    description: 'A monitoring tool for uptime and performance checks on websites and services.',
+    description: 'Website monitoring: uptime and performance.',
     image: '/images/monitor.webp',
     tags: ['Monitoring', 'Utilities'],
     visit: 'https://monitor.samiralibabic.com',
@@ -97,7 +97,7 @@ export const projects = [
   },
   {
     title: 'Affiliate Companies',
-    description: 'Discover the top affiliate programs with excellent earning potential.',
+    description: 'Affiliate program directory.',
     image: '/images/affiliatecompanies.webp',
     tags: ['Affiliate Marketing', 'Directory'],
     visit: 'https://affiliatecompanies.net',
@@ -105,7 +105,7 @@ export const projects = [
   },
   {
     title: 'Print On Demand Business',
-    description: 'A comprehensive directory of suppliers for your print-on-demand businesses.',
+    description: 'Find and compare print-on-demand suppliers.',
     image: '/images/printondemandbusiness.webp',
     tags: ['Print-On-Demand', 'Directory'],
     visit: 'https://printondemandbusiness.com',
@@ -113,7 +113,7 @@ export const projects = [
   },
   {
     title: 'Tierarzt-Liste',
-    description: 'A comprehensive veterinarian directory for Germany with over 1849 veterinarians in 1057 practices and clinics.',
+    description: 'Find vets in Germany. Local and structured.',
     image: '/images/tierarzt-liste.webp',
     tags: ['Directory', 'Healthcare', 'Veterinary'],
     visit: 'https://tierarzt-liste.de',
@@ -121,7 +121,7 @@ export const projects = [
   },
   {
     title: 'ClipClean',
-    description: 'An AI-powered audio cleaning service that removes filler words and awkward pauses from podcasts and recordings.',
+    description: 'Cleaner audio: fewer filler words, fewer awkward pauses.',
     image: '/images/clipclean.webp',
     tags: ['SaaS', 'AI', 'Audio Processing'],
     visit: 'https://clipclean.eu',


### PR DESCRIPTION
### Motivation
- Avoid awkward 3+1 masonry layouts on wider viewports by changing masonry breakpoints to a cleaner 4→2→1 stepdown.  
- Surface short helper lines for grouped projects so utilities and archived/inactive groups are clearer.  
- Reduce verbose/fluctuating UI copy and remove a moving metric to keep the hero and project copy concise and stable.

### Description
- Update Masonry breakpoints in `src/components/Projects/Projects.js` to `default: 4, 1200: 2, 700: 1` to eliminate the 3-column intermediate layout.  
- Add `ProjectGroupHelper` styled component in `src/components/Projects/ProjectsStyles.js` and render helper lines for utilities and inactive groups in `src/components/Projects/Projects.js`.  
- Shorten and standardize copy across `public/locales/{en,de}/{common,projects}.json` and `src/constants/constants.js`, including renaming project group labels (`utilities` → `Labs`, `inactive` → `Archive`) and adding `utilitiesHelper` / `inactiveHelper` keys.  
- Remove the MAU proof chip from `src/components/Hero/Hero.js` to avoid showing a fluctuating metric.

### Testing
- Started the dev server with `npm run dev -- --hostname 0.0.0.0 --port 3000` and the app compiled successfully and served `GET / 200`.  
- Ran a Playwright script that loaded the homepage at `1600x900` and saved a screenshot to `artifacts/homepage-grid-wide.png`.  
- The dev run produced non-blocking runtime warnings: Google Fonts failed to download (fallback used) and a styled-components warning about a non-boolean `center` prop, neither of which blocked compilation or rendering.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a9f378654832cb87368b325204d1c)