### PR TITLE
Map samiralibabic domains to Umami website IDs

### DIFF
--- a/src/pages/_app.js
+++ b/src/pages/_app.js
@@ -14,8 +14,8 @@ const spaceGrotesk = Space_Grotesk({
 })
 
 const UMAMI_WEBSITE_IDS = {
-  'tierarzt-liste.com': '6e08ea50-4ca6-434a-9615-c52e47371a2f',
-  'tierarzt-liste.de': 'd7457f3d-15d3-4d6d-b662-ae2dc867064d',
+  'samiralibabic.com': '6e08ea50-4ca6-434a-9615-c52e47371a2f',
+  'samiralibabic.de': 'd7457f3d-15d3-4d6d-b662-ae2dc867064d',
 };
 
 const UMAMI_SCRIPT_SRC = 'https://analytics.tierarzt-liste.de/script.js';


### PR DESCRIPTION
### Motivation
- Ensure the Umami analytics script only runs for the samiralibabic domains and uses the specific website IDs you provided so the pages send data to `https://analytics.tierarzt-liste.de` matching the two snippet variants. 

### Description
- Replace the previous Umami domain mapping with entries for `samiralibabic.com` and `samiralibabic.de` in `src/pages/_app.js` and keep `UMAMI_SCRIPT_SRC` set to `https://analytics.tierarzt-liste.de/script.js`, which results in the Next `Script` being injected with the corresponding `data-website-id` for the current hostname. 

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696aa7ebd3e8832c89e84ddc33ade7dd)