### PR TITLE
Allow Umami analytics host in Vercel CSP

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -18,7 +18,7 @@
       "headers": [
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://testimonial.to https://*.testimonial.to https://www.googletagmanager.com https://www.google-analytics.com https://vitals.vercel-insights.com *.vercel-insights.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://*.testimonial.to; img-src 'self' data: blob: https://*.testimonial.to https://www.google-analytics.com; font-src 'self' https://fonts.gstatic.com data:; connect-src 'self' https://*.testimonial.to https://www.google-analytics.com https://vitals.vercel-insights.com *.vercel-insights.com; frame-src 'self' https://embed-v2.testimonial.to https://testimonial.to https://*.testimonial.to; object-src 'none'"
+          "value": "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://testimonial.to https://*.testimonial.to https://www.googletagmanager.com https://www.google-analytics.com https://vitals.vercel-insights.com *.vercel-insights.com https://analytics.tierarzt-liste.de; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://*.testimonial.to; img-src 'self' data: blob: https://*.testimonial.to https://www.google-analytics.com; font-src 'self' https://fonts.gstatic.com data:; connect-src 'self' https://*.testimonial.to https://www.google-analytics.com https://vitals.vercel-insights.com *.vercel-insights.com https://analytics.tierarzt-liste.de; frame-src 'self' https://embed-v2.testimonial.to https://testimonial.to https://*.testimonial.to; object-src 'none'"
         },
         {
           "key": "X-Content-Type-Options",


### PR DESCRIPTION
### Motivation
- Allow the Umami analytics host `https://analytics.tierarzt-liste.de` in the site Content-Security-Policy so analytics scripts and network requests are permitted by edge headers.

### Description
- Updated `vercel.json` to add `https://analytics.tierarzt-liste.de` to the `script-src` and `connect-src` directives in the `Content-Security-Policy` header.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696aaf386844832cafd16e52d1aa0313)