### PR TITLE
Adjust projects grid to two columns on large screens

### DIFF
--- a/src/components/Projects/ProjectsStyles.js
+++ b/src/components/Projects/ProjectsStyles.js
@@ -59,10 +59,13 @@ export const BlogCard = styled.div`
 
 export const GridContainer = styled.div`
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  grid-template-columns: repeat(2, minmax(300px, 1fr));
   gap: 2rem;
   padding: ${(props) => props.nopadding ? '0' : '3rem'};
   grid-auto-flow: dense;
+  @media ${(props) => props.theme.breakpoints.md} {
+    grid-template-columns: minmax(0, 1fr);
+  }
   @media ${(props) => props.theme.breakpoints.sm} {
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
### Motivation
- The projects/products grid used `repeat(auto-fill, minmax(300px, 1fr))` which could produce more than two cards per row, while the intended layout is two cards per row on larger screens and a single column on medium screens.

### Description
- Changed the grid template to `grid-template-columns: repeat(2, minmax(300px, 1fr))` in `src/components/Projects/ProjectsStyles.js` to enforce two columns on large screens.
- Added a `@media ${(props) => props.theme.breakpoints.md}` rule that sets `grid-template-columns: minmax(0, 1fr)` so the grid stacks to a single column at the `md` breakpoint.
- Minor formatting/context preserved around the `GridContainer` styled component.

### Testing
- Ran `npm run dev` to start the Next.js dev server and it reported as ready.
- Attempted a Playwright visual test to capture a screenshot but the Chromium process crashed, so the visual test failed.
- No automated unit tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69732f235130832c8b39df5c57fa1b7a)