### PR TITLE
Adjust projects masonry to two-column desktop layout

### DIFF
--- a/src/components/Projects/Projects.js
+++ b/src/components/Projects/Projects.js
@@ -26,9 +26,8 @@ import { projects } from '../../constants/constants';
 
 // Masonry breakpoints
 const breakpointColumnsObj = {
-  default: 4,
-  1200: 2,
-  700: 1
+  default: 2,
+  900: 1
 };
 
 // Container style for better mobile centering


### PR DESCRIPTION
### Motivation
- Ensure the Projects section displays two project cards per row on desktop so the grid shows “two in a row” rather than a larger multi-column layout.

### Description
- Updated the Masonry `breakpointColumnsObj` in `src/components/Projects/Projects.js` to `default: 2` and `900: 1` so desktop shows two columns and smaller viewports fall back to a single column.

### Testing
- Started the dev server with `npm run dev` (Next.js reported ready), then attempted an automated Playwright screenshot to validate layout but the Chromium run crashed so visual verification was not captured.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973321b3040832ca5bc8960d6b8a111)